### PR TITLE
Roteia so o gateway, com PAC e um SOCKS local

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GoLiveBypass — Bypass do Go Live no Discord (Brasil)
 
-Plugin para **Equicord** e **Vencord**, feito por um desenvolvedor brasileiro, que **devolve o Go Live e a câmera para usuários brasileiros**. São duas travas: o Discord desabilita os próprios botões, e o servidor recusa a transmissão. O plugin desarma a primeira direto no cliente, e a segunda criando a sua sessão atrás de uma proxy — só o WebSocket de gateway passa por ela, todo o resto sai direto, na sua velocidade normal.
+Plugin para **Equicord** e **Vencord**, feito por um desenvolvedor brasileiro, que **devolve o Go Live e a câmera para usuários brasileiros**. São duas travas: o Discord desabilita os próprios botões, e o servidor recusa a transmissão. O plugin desarma a primeira direto no cliente, e a segunda mandando **apenas o WebSocket de gateway** por uma saída fora do Brasil — todo o resto do Discord, e todo o resto do computador, continua saindo direto na velocidade normal, inclusive durante a abertura do app.
 
 > **English summary below / Resumo em inglês no final.**
 
@@ -40,9 +40,11 @@ Um script faz tudo: acha o seu Equicord ou Vencord, instala o plugin, compila e 
 
 Em agosto de 2026, a ANPD [ordenou que o Discord suspendesse as transmissões ao vivo (Go Live) no Brasil](https://www.gov.br/anpd/pt-br/assuntos/noticias/em-medida-preventiva-anpd-determina-que-discord-suspenda-transmissoes-ao-vivo-no-brasil), pouco depois de o país ter bloqueado o X (Twitter). Para quem depende dessas plataformas para se comunicar, organizar e denunciar, o recado foi claro: o acesso e a privacidade dos brasileiros na internet podem ser cortados por canetaço.
 
-O GoLiveBypass nasce dessa luta. Ele é uma ferramenta de **privacidade e resistência à censura**: garante que o momento mais sensível da sua sessão — a autenticação, quando sua conta é vinculada ao seu endereço de IP — aconteça atrás de uma proxy anônima.
+O GoLiveBypass nasce dessa luta. Ele é uma ferramenta de **resistência à censura**: devolve o que foi cortado por canetaço, sem pedir licença e sem entregar o resto da sua conexão em troca.
 
-**O que ele entrega, verificado na prática:** como a sessão do Discord nasce inteira atrás da proxy, o **Go Live e a câmera voltam a funcionar** para contas brasileiras — veja a seção abaixo.
+**O que ele entrega, verificado na prática:** como o WebSocket de gateway nasce fora do Brasil, o **Go Live e a câmera voltam a funcionar** para contas brasileiras — veja a seção abaixo.
+
+Se você também quer que a **autenticação** aconteça atrás da saída, e não pelo seu IP real, mude **Session routing** para `Gateway and login`. Não é o padrão porque custa tempo de abertura, e porque login por proxy pública costuma render captcha.
 
 ## Go Live no Brasil: por que funciona
 
@@ -52,11 +54,11 @@ Testes práticos mostram que o bloqueio do Go Live funciona assim:
 - O WebSocket do gateway é aberto no boot do app. Se ele nasce atrás de uma proxy fora do Brasil, o gate de região libera telas e câmera para contas brasileiras.
 - A mídia (UDP) não passa por verificação nenhuma — ela pode sair direta pelo seu IP real sem derrubar a liberação.
 
-Ou seja, o fluxo do GoLiveBypass — **boot inteiro atrás da proxy → proxy removida após a sessão abrir** — reproduz automaticamente o bypass manual "ligar VPN, abrir o Discord, entrar na call, desligar a VPN".
+Ou seja, o bypass manual "ligar VPN, abrir o Discord, entrar na call, desligar a VPN" funciona porque só o gateway precisava da VPN. O plugin faz exatamente isso, e nada além disso: `gateway.discord.gg` sai pela saída escolhida, todo o resto sai direto, o tempo inteiro.
 
 **Ressalvas honestas:**
 
-- A liberação vale enquanto o WebSocket do gateway continuar vivo. Se ele cair e reconectar pelo seu IP real (queda de internet, notebook suspenso), a próxima entrada em canal de voz volta a ser avaliada como BR. **Ctrl+R não resolve**: o proxy só é aplicado antes do gateway nascer, então é preciso fechar o Discord pela bandeja e abrir de novo.
+- A liberação vale enquanto o WebSocket do gateway continuar vivo, e ele continua roteado o tempo todo. Se cair e reconectar (queda de internet, notebook suspenso), o socket novo nasce pela mesma saída e a liberação sobrevive. Ctrl+R também. Isso é uma mudança em relação às versões que aplicavam proxy só no boot, onde qualquer reconexão custava o Go Live até reiniciar o app.
 - Isso depende de comportamento atual do Discord, que pode mudar a qualquer momento.
 - Usar proxy/VPN para contornar a restrição pode violar os Termos de Serviço do Discord. Risco de punição à conta é baixo, mas existe — considere usar uma conta secundária.
 
@@ -65,8 +67,9 @@ Ou seja, o fluxo do GoLiveBypass — **boot inteiro atrás da proxy → proxy re
 - **Só funciona no Discord para computador** com Equicord ou Vencord injetado. Vesktop e Equibop não são suportados pelos instaladores: eles trazem o mod embutido e não carregam de um checkout. Não funciona na versão de navegador/extensão.
 - **Proxies gratuitas são fracas para anonimato**: o operador da proxy vê seus metadados de conexão, muitas estão mortas ou lentas, e o Discord pode pedir captcha para IPs de proxies públicas. Para anonimato real, **use Tor**.
 - Usar clientes modificados viola os Termos de Serviço do Discord. Use por sua conta e risco.
-- A proxy cobre apenas a **criação da sessão**. Depois que a sessão abre (`CONNECTION_OPEN`), o tráfego volta a ser direto com seu IP real.
-- **O plugin nunca te deixa sem Discord.** Se a proxy falhar, o Chromium cai sozinho para conexão direta, e o processo principal remove a proxy em no máximo 120 segundos. O pior caso é abrir o Discord *sem* Go Live, nunca ficar sem conseguir abrir.
+- A saída cobre **apenas o gateway**. No padrão, o seu login e todo o resto do tráfego saem pelo seu IP real. Se você quer que a autenticação também vá escondida, mude **Session routing** para `Gateway and login` — ciente de que aí o boot fica mais lento.
+- **O plugin nunca te deixa sem Discord.** A saída morrendo custa o Go Live, não o app — o roteador local cai sozinho para conexão direta, e isso é coberto por teste. Não existe mais prazo de 120 segundos nem marca de boot, porque não existe mais o cenário que eles cobriam, o de uma proxy quebrada segurando o Discord inteiro.
+- **Quem opera a saída vê o seu tráfego de gateway.** É pouca coisa em bytes e vai toda dentro de TLS, mas é o canal por onde passam suas mensagens em tempo real. Uma proxy gratuita significa um desconhecido nesse lugar. Um servidor seu, ou o Tor, não.
 
 ## Como funciona
 
@@ -82,31 +85,48 @@ O plugin esvazia a tabela de variações desse experimento. Qualquer bucket que 
 
 Destravar o cliente não basta: o servidor decide separadamente se você pode transmitir, e essa decisão é tomada **uma única vez, quando você entra no canal de voz**, a partir do IP de origem da **conexão de gateway** (o WebSocket que carrega o `VOICE_STATE_UPDATE`). Depois disso não há reavaliação: o servidor de voz só transporta mídia por UDP.
 
-Por isso o plugin proxia **só o gateway**:
+Por isso o plugin roteia **só o gateway**, e é aqui que está a diferença de velocidade.
 
-1. Na abertura do app, antes do Discord abrir o WebSocket, o proxy é aplicado (o seu manual, ou um Tor local se estiver rodando).
-2. O gateway nasce atrás do proxy. Como o Chromium prende cada conexão à rota que ela tinha ao nascer, esse socket fica no proxy para sempre.
-3. Assim que a sessão abre (`CONNECTION_OPEN`), o plugin devolve a sessão para conexão direta. O gateway continua no proxy; **todo o resto** (API, CDN, anexos, atualizações e a mídia das calls) passa a sair direto, na sua velocidade normal.
-4. O plugin então confere a atribuição do experimento no servidor e te diz num toast se a sessão ficou liberada de verdade.
+O `session.setProxy` do Electron vale para a sessão inteira. Ele não sabe dizer "esta conexão sim, aquela não". Uma versão que só tenha essa ferramenta é obrigada a mandar o boot inteiro pela proxy e tirar depois, e é isso que fazia o Discord demorar — o app subia por uma proxy pública, e ainda esperava a escolha dela terminar antes de começar a subir.
 
-O momento importa e é mais estrito do que parece: um socket criado **antes** do proxy ser aplicado fica preso na conexão direta para sempre. Proxiar depois que o app subiu não adianta.
+O Chromium tem uma segunda porta de entrada que resolve as duas coisas: **PAC**. Em `pac_script`, o campo `pacScript` recebe uma URL, e a resposta dela é uma função `FindProxyForURL(url, host)` que decide **por host**. É só disso que o plugin precisa:
 
-### Como as proxies gratuitas são escolhidas
+1. Um **SOCKS5 local**, na abertura do app, que recebe só o que o PAC mandar e decide na hora por onde sair.
+2. Um **PAC embutido numa `data:` URL** — sem servidor, sem arquivo, sem busca — dizendo que `gateway.discord.gg` vai para esse roteador e que **qualquer outro host segue a regra que o sistema já usava**, lida pelo `resolveProxy` antes de tudo. Quem está atrás de proxy corporativo não perde o Discord.
 
-- A lista da ProxyScrape já traz `alive`, `uptime` e `timeout`. O plugin **ranqueia por esses campos** (uptime >= 90, timeout <= 1500ms) em vez de sortear a lista.
+Subir o roteador leva milissegundos, então ele está de pé muito antes do gateway nascer. A escolha da saída acontece **depois**, em paralelo com o Discord carregando. Quando o gateway chega no roteador antes de existir saída, ele fica segurado ali (até 12 segundos) enquanto o resto do app carrega na velocidade normal. É a inversão que interessa — em vez do app inteiro esperar a proxy, uma única conexão espera, e ela é justamente a que precisa esperar.
+
+O que foi verificado com um Chromium de verdade, passando o Edge pelo roteador:
+
+- o PAC entregue como `data:` URL é obedecido, e `SOCKS5 127.0.0.1:porta` como retorno funciona;
+- a separação por host é real: `gateway.discord.gg` atravessou o roteador e o `example.com` inteiro, com todos os subrecursos, saiu direto sem encostar nele;
+- segurar a resposta do SOCKS5 por 6 segundos não derruba o pedido — o Chromium espera e carrega;
+- com a saída apontando para uma porta morta, a página ainda carrega, porque o roteador cai para direto sozinho.
+
+O que **não** dá para verificar sem uma conta bloqueada de verdade: se rotear só o gateway basta para liberar o Go Live, ou se o gate também olha o IP do login. Se no seu caso não bastar, mude **Session routing** para `Gateway and login`.
+
+### Como as saídas são escolhidas
+
+A ordem é a seguinte — a proxy que você escreveu, depois as que já funcionaram antes, depois um Tor local, depois a lista gratuita.
+
+- **As que já funcionaram ficam guardadas.** Até cinco delas, com a latência medida, em `native-settings.json`. No boot seguinte todas são testadas juntas e a primeira a responder ganha. A busca cara na lista gratuita acontece com a sessão já aberta, para reabastecer o pote, e não mais no caminho da abertura do app.
+- **Um teste só, em vez de dois.** A validação bate em `cloudflare.com/cdn-cgi/trace`, que responde em cerca de 200 bytes e já prova as quatro coisas de uma vez: o túnel SOCKS abre, o TLS fecha com certificado válido (proxy que intercepta morre aqui), veio HTTP 200, e de que país ela sai. A versão anterior gastava duas conexões para saber o mesmo, uma no `discord.com` e outra no `ifconfig.co`.
+- **Candidatas correm juntas.** Doze por vez, e a primeira aceitável ganha. Antes o teste de país rodava uma por vez, depois do lote inteiro terminar, o que sozinho podia somar um minuto.
+- A lista da ProxyScrape já traz `alive`, `uptime` e `timeout`, e o plugin **ranqueia por esses campos** (uptime >= 90, timeout <= 1500ms) em vez de sortear.
 - Descarta a porta 4145: numa amostra medida, 14 de 14 proxies nessa porta interceptavam TLS com certificado forjado.
-- Testa até 10 candidatas **em paralelo**, e o teste é um **handshake TLS real + `GET /api/v9/gateway` exigindo HTTP 200**, não apenas o handshake SOCKS.
-- Confirma o **país de saída real** por TLS antes de usar, porque o `countryCode` da lista descreve o IP de entrada, que frequentemente é diferente do de saída.
+- Confirma o **país de saída real**, porque o `countryCode` da lista descreve o IP de entrada, que frequentemente é diferente do de saída.
 
-Medido: escolher aleatoriamente e testar só o handshake acerta 12% das vezes; ranquear e exigir TLS real acerta 60%. Ainda assim, um Tor local ganha de qualquer lista gratuita, e é por isso que o plugin o prefere.
+**O melhor caminho continua não sendo lista gratuita.** Uma máquina sua fora do Brasil, com `ssh -D 1080 seu-servidor` e `socks5://127.0.0.1:1080` no campo Proxy, é estável, rápida, e não coloca um desconhecido no meio do seu gateway. As camadas gratuitas existem para quem não tem isso, não porque sejam boas.
 
 ### Proteções contra travar o Discord
 
-- **Fallback direto**: a proxy é aplicada como `proxy,direct://`, então se ela morrer o Chromium usa conexão direta sozinho.
-- **Prazo no processo principal**: 120s depois de aplicada, a proxy sai sozinha. O prazo vive no processo principal, que tem rede sadia, e não no renderer, que é justamente o que a proxy quebrada impede de carregar.
-- **`did-fail-load`**: se a página principal falhar em carregar, a proxy sai na hora.
-- **Marca de boot**: se uma inicialização aplicou proxy e nunca terminou, a inicialização seguinte se recusa a aplicar.
-- **Proxy gratuita só é reaproveitada depois de passar no teste de novo.** A última que funcionou fica guardada em `native-settings.json` sob `verifiedProxy` por 24h, e no boot seguinte ela é testada outra vez (orçamento de 2,5s) antes de ser aplicada. Descobrir uma do zero leva de 8 a 23 segundos e o gateway conecta antes disso, por isso o cache existe. O que causava o travamento antigo era reaplicar sem testar, e isso não acontece mais.
+Rotear só um host muda o pior caso. Uma saída ruim agora atinge uma conexão, não o app — e por isso a maior parte das proteções antigas deixou de ter motivo para existir.
+
+- **O roteador local cai para direto sozinho.** Se a saída não abrir, ou se ela demorar demais para ser escolhida, ele conecta ao destino sem intermediário — custa o Go Live daquela sessão, e nada além. Recusar seria custar o Discord, porque a conexão em questão é o gateway.
+- **A rede de segurança vive dentro do roteador, e não numa alternativa do PAC.** O host roteado sai por ele e ponto, sem `DIRECT` depois do ponto e vírgula. Ter essa alternativa custou uma sessão inteira durante o desenvolvimento: uma saída gratuita falhou uma vez, o Chromium marcou o SOCKS local como ruim, e a partir dali mandou tudo pela alternativa sem avisar ninguém — PAC no lugar, roteador escutando, e nenhuma conexão passando por ele.
+- **Nada é aplicado fora do Discord.** Todo host que não está na lista recebe exatamente a regra que já valia antes do plugin existir.
+- **Não existe mais prazo de 120 segundos**, porque não existe mais o cenário em que uma proxy quebrada segurava o app inteiro e precisava ser arrancada à força.
+- **Não existe mais marca de boot.** Ela protegia contra o mesmo cenário, e tinha um efeito colateral ruim — qualquer inicialização que não terminasse (fechar o Discord na tela de login, por exemplo) fazia a inicialização seguinte se recusar a aplicar proxy, em silêncio. Na prática dava para ficar alternando entre um boot que libera e um que não libera sem entender o motivo. Quem vem de uma versão anterior pode apagar `bootPending` e `verifiedProxy` do `native-settings.json`, que não são mais lidos.
 
 ## Instalação automática (recomendado)
 
@@ -311,7 +331,7 @@ O instalador abre uma janelinha perguntando **qual Discord** você usa (Stable, 
 1. Abra o Discord
 2. Vá em **Configurações → Equicord (ou Vencord) → Plugins** e ative **GoLiveBypass**
 3. Deixe **Voice region** em `Automatic`, que é o padrão (leia o aviso abaixo antes de mudar)
-4. Reinicie o Discord por completo (bandeja, Quit). O plugin escolhe o proxy e aplica antes do gateway conectar, depois solta o resto
+4. Reinicie o Discord por completo (bandeja, Quit). O roteador sobe junto com o app, e a saída é escolhida enquanto o Discord carrega
 5. Entre num canal de voz: **Go Live e câmera liberados**. Quem escolhe o servidor de voz é o Discord, e pode não ser o brasileiro. Não force `brazil` em **Voice region** sem ler o aviso na seção Configuração
 
 ## Configuração
@@ -323,26 +343,29 @@ Nas settings do plugin:
   > **Cuidado ao forçar `brazil` aqui.** Há indício de que o servidor de mídia brasileiro é justamente onde a transmissão é recusada: numa sessão em que a call caiu no Brasil o Go Live não subiu, e numa sessão em que caiu em Santiago funcionou. São duas observações, não uma prova, mas o padrão seguro é não forçar. Use este campo se quiser priorizar latência e estiver disposto a perder o Go Live.
 
   Vale saber que isto é uma **preferência**, não uma ordem: o Discord pode ignorar e escolher outra região, e foi o que aconteceu no teste.
-- **Proxy**: proxy usada só na criação da sessão, no formato `esquema://host:porta` (`socks5`, `http` ou `https`).
+- **Session routing**: o que passa pela saída. Padrão `Gateway only` — o mais rápido, e o único necessário para liberar o Go Live. Em `Gateway and login`, o `discord.com` também passa pela saída enquanto você autentica, o que esconde seu endereço real nesse momento e deixa a abertura do app mais lenta. Assim que a sessão abre, o escopo encolhe sozinho de volta para o gateway.
+- **Proxy**: a saída do gateway — no formato `esquema://host:porta` (`socks5`, `http` ou `https`).
+  - Um servidor seu é a melhor opção: `ssh -D 1080 usuario@seu-servidor` e depois `socks5://127.0.0.1:1080` aqui.
   - Tor, se você usa: `socks5://127.0.0.1:9150` com o **Tor Browser** aberto, ou `socks5://127.0.0.1:9050` para o **daemon** `tor`.
-  - **Deixe vazio** para o plugin detectar um Tor local automaticamente e, se não achar, buscar uma proxy gratuita validada.
+  - **Deixe vazio** para o plugin reaproveitar uma saída já testada, detectar um Tor local, ou buscar uma gratuita validada, nessa ordem.
 - **Excluded countries**: códigos de país de duas letras separados por vírgula que nunca são usados (padrão: `BR`). O país conferido é o de **saída real**, medido através da proxy, não o que a lista afirma.
 
 ## Uso
 
-1. Abra o Discord normalmente. O plugin escolhe o proxy e aplica antes do gateway conectar.
-2. Se você escolheu Tor no instalador, deixe o Tor aberto antes; com proxy gratuita não precisa fazer nada.
-3. Espere o toast. `Go Live is unlocked on this session` significa que o servidor liberou e o proxy já saiu de tudo que não é o gateway. `Discord still has Go Live blocked` significa que o gateway subiu sem o proxy: feche o Discord de verdade (bandeja, Quit) e abra de novo.
+1. Abra o Discord normalmente. O roteador sobe junto e a saída é escolhida em paralelo, sem segurar o app.
+2. Se você escolheu Tor, deixe o Tor aberto antes; com saída automática não precisa fazer nada.
+3. Espere o toast. `Go Live is unlocked` diz por qual saída o gateway ficou. `Discord still has Go Live blocked` diz o que falhou — se nenhuma saída foi encontrada a tempo, feche o Discord de verdade (bandeja, Quit) e abra de novo; se uma saída foi usada e mesmo assim ficou bloqueado, troque a saída ou mude **Session routing** para `Gateway and login`.
 4. Entre na call e transmita.
 
-Se o Discord reconectar o gateway sozinho no meio da sessão (queda de rede, suspender o notebook), o socket novo nasce direto e o desbloqueio se perde até você reiniciar o app. O toast do próximo `CONNECTION_OPEN` avisa quando isso acontece.
+Reconexão do gateway no meio da sessão não custa mais o desbloqueio — o socket novo nasce pela mesma saída, porque a regra continua valendo. Ctrl+R também funciona.
 
 ## Solução de problemas
 
-- **Discord carregando infinitamente**: normalmente ele se resolve sozinho, porque uma inicialização que não terminou deixa uma marca e a seguinte se recusa a aplicar proxy. Se persistir, com o Discord fechado abra `%APPDATA%/Equicord/settings/settings.json` (ou `.../Vencord/...`) e coloque `"GoLiveBypass": { "enabled": false }`. Em `native-settings.json` as chaves deste plugin são `verifiedProxy` (a proxy guardada) e `bootPending` (a marca); apagar as duas devolve tudo ao estado inicial. Se você usou uma versão anterior, apague também `lastKnownProxy`, que não é mais lida.
-- **"GoLiveBypass is reconnecting behind the proxy"**: a proxy ficou pronta depois de o gateway já ter conectado, então a sessão nasceu desprotegida e o servidor manteve o bloqueio. O plugin procura uma proxy que responda e recarrega o cliente sozinho para a sessão renascer atrás dela. São no máximo duas tentativas: sem esse teto, um bloqueio que a proxy não resolve viraria recarregamento sem fim.
-- **"No proxy could carry a real request to Discord"**: nenhuma candidata passou no teste TLS real naquele momento. Tente de novo, ou use Tor / uma proxy sua no campo Proxy.
-- **Quer ver o que aconteceu**: rode `/golivebypass` em qualquer canal. Ele copia um diagnóstico com o estado das travas, da transmissão, da região e o registro do processo principal — qual proxy foi testada, quanto tempo levou, em que país ela sai e por que foi recusada.
+- **Discord carregando infinitamente**: não deveria mais acontecer por causa do plugin, já que ele não roteia nada além de `gateway.discord.gg` e cai para direto sozinho. Se acontecer mesmo assim, com o Discord fechado abra `%APPDATA%/Equicord/settings/settings.json` (ou `.../Vencord/...`) e coloque `"GoLiveBypass": { "enabled": false }`. Em `native-settings.json` a chave deste plugin é `pool` (as saídas guardadas), e apagá-la devolve tudo ao estado inicial. Se você vem de uma versão anterior, apague também `verifiedProxy`, `bootPending` e `lastKnownProxy`, que não são mais lidas.
+- **"GoLiveBypass is reloading behind the exit"**: a saída ficou pronta depois de o gateway já ter conectado, então a sessão nasceu desprotegida e o servidor manteve o bloqueio. O plugin procura uma saída que responda e recarrega o cliente sozinho para a sessão renascer atrás dela. São no máximo duas tentativas: sem esse teto, um bloqueio que a saída não resolve viraria recarregamento sem fim.
+- **"GoLiveBypass could not unlock this session"**: as tentativas acabaram e a sessão continua bloqueada. Aponte o campo **Proxy** para um servidor seu e reinicie o Discord pela bandeja. Rotear só o gateway pode não ter bastado no seu caso: **Session routing** em `Gateway and login` manda o `discord.com` junto durante a autenticação.
+- **Nenhuma saída passou nos testes**: nenhuma candidata fechou TLS com certificado válido naquele momento. Tente de novo, ou use Tor ou uma proxy sua no campo Proxy.
+- **Quer ver o que aconteceu**: rode `/golivebypass` em qualquer canal. Ele copia um diagnóstico com o estado das travas, da transmissão, da região e o registro do processo principal — qual saída foi testada, quanto tempo levou, em que país ela sai e por que foi recusada.
 - **A região da call não mudou**: saia e entre de novo no canal. Canais de servidor com região fixada por um admin ignoram sua preferência, e numa call que já está rolando a região já foi decidida.
 - **Captcha ou verificação de telefone no login**: o Discord marca muitos IPs de proxies públicas. Use Tor ou outra proxy.
 - **`Cannot find matching keyid` ao instalar as dependências**: é o corepack, não o plugin. Ele cria o atalho do `pnpm` antes de saber que versão usar, e na primeira execução busca essa versão no registro do npm conferindo a assinatura com chaves embutidas nele — as que vêm no Node 22 estão vencidas. O instalador detecta isso e instala o pnpm pelo npm. Se estiver fazendo à mão, rode `npm install -g pnpm` e siga com `pnpm install`.
@@ -355,8 +378,9 @@ Se o Discord reconectar o gateway sozinho no meio da sessão (queda de rede, sus
 goLiveBypass/
 ├── index.tsx                      # renderer: patches do video guard e do stream, seletor de região,
 │                                  #   override do RTCRegionStore, eventos de fluxo
-└── native.ts                      # processo principal: session.setProxy, validação TLS das proxies,
-                                   #   detecção de Tor, registro, nova tentativa, prazos de segurança
+└── native.ts                      # processo principal: roteador SOCKS5 local e PAC por data: URL,
+                                   #   escolha e validação TLS das saídas, detecção de Tor,
+                                   #   registro e nova tentativa
 
 installer/
 ├── GoLiveBypass-Installer.bat     # Windows: dois cliques, libera a execução e chama o .ps1
@@ -389,17 +413,22 @@ desse trabalho.
 
 # English
 
-**GoLiveBypass** is an **Equicord/Vencord** plugin, made by a Brazilian developer, that **restores Go Live and camera for Brazilian Discord users**: it boots Discord entirely behind a proxy outside Brazil (Tor or a tested, automatically fetched free proxy) **on every launch and reload**, so Discord's region gate — evaluated once at voice-channel join using the gateway WebSocket origin IP, and never re-evaluated mid-call — unlocks the features. The proxy is dropped once the session opens, restoring a direct connection. As a bonus, your real IP stays hidden during authentication.
+**GoLiveBypass** is an **Equicord/Vencord** plugin, made by a Brazilian developer, that **restores Go Live and camera for Brazilian Discord users**. Discord's region gate is evaluated once at voice-channel join, from the gateway WebSocket origin IP, and never re-evaluated mid-call, so that single socket is the only thing that needs to leave Brazil.
 
-It was written after Brazil's data protection authority (ANPD) [ordered Discord to suspend live streaming (Go Live) in Brazil](https://www.gov.br/anpd/pt-br/assuntos/noticias/em-medida-preventiva-anpd-determina-que-discord-suspenda-transmissoes-ao-vivo-no-brasil) in August 2026, shortly after the country blocked X (Twitter). It works while the gateway WebSocket stays alive. If it reconnects over your real IP, Ctrl+R will not help: the proxy is only applied before the gateway is created, so you have to quit Discord from the tray and open it again. Bypassing the restriction may violate Discord's ToS.
+The plugin routes exactly that. On startup it brings up a local SOCKS5 router and installs a PAC embedded in a `data:` URL — no server, no file, no fetch — that sends only `gateway.discord.gg` to the router; every other host keeps whatever rule the system already had, read from `resolveProxy` beforehand. Startup costs milliseconds, so the exit is chosen afterwards, in parallel with Discord loading, instead of holding the whole boot. A gateway connection that arrives before an exit exists waits at the local router for up to 12 seconds while the rest of the app loads at full speed.
+
+Verified against real Chromium: a PAC delivered as a `data:` URL is honoured and `SOCKS5 127.0.0.1:port` works as a return value; per-host separation is real (the routed host crossed the router while another site loaded fully without touching it); holding the SOCKS5 reply for 6 seconds does not kill the request; and with the exit pointed at a dead port the page still loads, because the router falls back to direct on its own. What cannot be verified without a blocked account: whether routing the gateway alone is enough, or whether the gate also reads the login IP. Switch **Session routing** to `Gateway and login` if it is not enough for you.
+
+It was written after Brazil's data protection authority (ANPD) [ordered Discord to suspend live streaming (Go Live) in Brazil](https://www.gov.br/anpd/pt-br/assuntos/noticias/em-medida-preventiva-anpd-determina-que-discord-suspenda-transmissoes-ao-vivo-no-brasil) in August 2026, shortly after the country blocked X (Twitter). Because the rule stays installed, a gateway reconnect keeps the unlock and Ctrl+R works. Bypassing the restriction may violate Discord's ToS.
 
 - Desktop Discord with Equicord or Vencord injected. Vesktop and Equibop are not supported by the installers, since they bundle the mod instead of loading it from a checkout. Not available on the browser extension.
 - Dependencies: Git, Node.js 22+, pnpm 11 (via `corepack enable`), and a desktop Discord client. Tor is optional, not required: by default the plugin picks and validates a free proxy on its own.
 - **Your calls stay on the region you pick.** Creating the session abroad makes Discord rank foreign voice servers, so the plugin overrides the three `RTCRegionStore` getters that feed `preferred_region` / `preferred_regions` in the gateway `VOICE_STATE_UPDATE`. The override is evaluated at read time, so Discord's latency test cannot undo it, and it writes nothing into Discord's persisted state, so the region is not left pinned after you remove the plugin. Restored on `stop()`.
-- Proxy order: your manual proxy, then a local Tor (`127.0.0.1:9150` for Tor Browser, `9050` for the daemon), then a validated free proxy.
-- Free proxies are weak for anonymity — prefer Tor.
-- Free proxies are ranked by the `alive` / `uptime` / `timeout` metadata the list already returns, port 4145 is dropped (measured 14/14 TLS interception), up to 10 candidates are probed in parallel with a real TLS handshake plus `GET /api/v9/gateway` expecting HTTP 200, and the exit country is verified over TLS. Measured: random pick with a handshake-only test works 12% of the time, ranked with a real TLS test works 60%.
-- It cannot leave you unable to open Discord: the proxy is installed as `proxy,direct://` so Chromium falls back on its own, a main-process deadline drops it after 120s, `did-fail-load` drops it immediately, a boot marker refuses to re-apply after a boot that never finished, and a free proxy is never persisted to disk.
+- Exit order: your manual proxy, then exits that already worked (up to five, kept with their measured latency and all probed together on the next boot), then a local Tor (`127.0.0.1:9150` for Tor Browser, `9050` for the daemon), then a validated free proxy. The expensive search over the free list runs once the session is already open, to refill the pool, not on the startup path.
+- Validation is a single request to `cloudflare.com/cdn-cgi/trace`, roughly 200 bytes, which proves the SOCKS tunnel opens, TLS closes with a valid certificate (intercepting proxies die here), HTTP 200 came back, and which country it exits from. Candidates are validated twelve at a time and the first acceptable one wins.
+- Free proxies are ranked by the `alive` / `uptime` / `timeout` metadata the list already returns, and port 4145 is dropped (measured 14/14 TLS interception).
+- Free proxies are weak for anonymity, and whoever runs the exit sees your gateway traffic. Your own machine abroad (`ssh -D 1080`, then `socks5://127.0.0.1:1080`) is the option with nobody else in the middle. Tor is the next best.
+- It cannot leave you unable to open Discord: the local router falls back to a direct connection if the exit fails or takes too long, the PAC keeps the system rule as its last resort, and nothing outside `gateway.discord.gg` is touched at all.
 - Install: copy the `goLiveBypass` folder into `src/userplugins/` of your Equicord or Vencord clone, then `pnpm install && pnpm build && pnpm inject`, fully restart Discord, and enable **GoLiveBypass** in plugin settings.
 - Made by **bezumiya** — [GitHub](https://github.com/bezumiya/GoLiveBypass), [Twitter](https://twitter.com/obezumiya), Discord `1366453661970071633`.
 - Thanks to **[Vithor](https://github.com/Vith0r)** for the installer: he wrote the first GoLiveBypass installer on his own and showed that the whole setup could be automated in a single script.

--- a/goLiveBypass/index.tsx
+++ b/goLiveBypass/index.tsx
@@ -59,8 +59,12 @@ const AUTOMATIC = "";
 const VOICE_KEYS: "voiceRegion"[] = ["voiceRegion"];
 const STREAM_KEYS: "streamRegion"[] = ["streamRegion"];
 
+// O experimento so e reavaliado alguns ticks depois do CONNECTION_OPEN. Perguntar na hora
+// exata do evento respondia "bloqueado" mesmo em sessao que tinha sido liberada.
+const VERDICT_DELAY_MS = 1500;
+
 let original: RegionStore | undefined;
-let bypassRequested = false;
+let lastScope: string | null = null;
 
 interface RegionSelectProps {
     value: string;
@@ -143,16 +147,24 @@ const settings = definePluginSettings({
         component: StreamRegionPicker,
         default: AUTOMATIC
     },
+    sessionRouting: {
+        type: OptionType.SELECT,
+        description: "What goes through the exit. Only the gateway is what unlocks Go Live, and it keeps the rest of Discord at full speed. Adding the login also hides your real address while you authenticate, at the cost of a slower start.",
+        options: [
+            { label: "Gateway only, fastest", value: "gateway", default: true },
+            { label: "Gateway and login, hides your address while you sign in", value: "login" }
+        ]
+    },
     proxy: {
         type: OptionType.STRING,
-        description: "Proxy used only while your session is being created, like socks5://127.0.0.1:9050 for Tor. Leave empty and your session is created through a free proxy picked and tested for you, which means a stranger carries your login.",
+        description: "Exit used by the gateway, like socks5://127.0.0.1:9050 for Tor. Leave empty to reuse a tested exit or find one automatically, which means a stranger carries your gateway traffic. Your own server is the only option nobody else is reading.",
         default: "",
         isValid: (value: string) => value.trim() === "" || /^(socks5|https?):\/\/[a-z0-9.-]{1,253}:\d{1,5}$/.test(value.trim())
             || "Use socks5://host:porta, http://host:porta ou https://host:porta."
     },
     excludedCountries: {
         type: OptionType.STRING,
-        description: "Two letter country codes, comma separated, whose proxies are never used. The real exit address is checked, not the one the list claims.",
+        description: "Two letter country codes, comma separated, whose exits are never used. The real exit address is checked, not the one the list claims.",
         default: "BR"
     }
 });
@@ -208,26 +220,6 @@ function restoreRegion() {
     original = undefined;
 }
 
-async function startBypass() {
-    if (!Native || bypassRequested) return;
-    bypassRequested = true;
-    showToast("GoLiveBypass is looking for a proxy. Wait for the next toast before you log in.");
-
-    try {
-        const result = await Native.enable(settings.store.excludedCountries);
-        if (result.success) {
-            showToast(`GoLiveBypass is creating your session through ${result.proxy}.`);
-            return;
-        }
-
-        bypassRequested = false;
-        showToast(`GoLiveBypass could not start. ${result.error}`, Toasts.Type.FAILURE);
-    } catch (error) {
-        bypassRequested = false;
-        logger.error("Failed to reach the desktop process", error);
-    }
-}
-
 function videoIsBlocked() {
     const user = UserStore.getCurrentUser();
     if (user == null) return false;
@@ -242,44 +234,61 @@ function videoIsBlocked() {
     return variantId === 1 || variantId === 2;
 }
 
-async function releaseProxy() {
+// Sem refazer o gateway a sessao fica bloqueada ate o proximo reinicio: a rota continua
+// instalada, mas o socket que importa ja nasceu fora dela. Recarregar e a unica saida, e o
+// processo principal limita quantas vezes isso pode acontecer.
+async function retryBehindExit() {
     if (!Native) return;
 
-    let wasProxied = false;
-    try {
-        wasProxied = await Native.getActiveProxy() !== null;
-        // So solta o proxy quando a sessao realmente ficou liberada: soltar antes de saber
-        // disso jogaria fora a unica chance de recarregar atras dele.
-        if (wasProxied && !videoIsBlocked()) await Native.disable();
-        bypassRequested = false;
-    } catch (error) {
-        logger.error("Failed to reach the desktop process", error);
-    }
-
-    if (!videoIsBlocked()) {
-        Native?.sessionWorked();
-        showToast(wasProxied
-            ? "Go Live is unlocked on this session. Only the gateway stays on the proxy, everything else is direct now."
-            : "Go Live is unlocked on this session, no proxy was needed.", Toasts.Type.SUCCESS);
-        return;
-    }
-
-    logger.warn("O servidor continuou bloqueando video: o gateway subiu sem passar pelo proxy.");
-
-    // Nao adianta soltar o proxy aqui: sem refazer o gateway a sessao fica bloqueada ate o
-    // proximo reinicio. Recarregar com o proxy no ar e a unica saida, e o processo principal
-    // limita quantas vezes isso pode acontecer.
     try {
         const result = await Native.retryWithProxy(settings.store.excludedCountries);
         if (result.retried) {
-            showToast(`GoLiveBypass is reconnecting behind the proxy (attempt ${result.attempt}).`);
+            showToast(`GoLiveBypass is reloading behind the exit (attempt ${result.attempt}).`);
             return;
         }
 
-        showToast(`GoLiveBypass could not unlock this session (${result.reason}). Open your proxy, then restart Discord from the tray.`, Toasts.Type.FAILURE);
+        showToast(`GoLiveBypass could not unlock this session (${result.reason}). Point Exit at a server of your own, then restart Discord from the tray.`, Toasts.Type.FAILURE);
     } catch (error) {
         logger.error("Failed to reach the desktop process", error);
     }
+}
+
+async function reportSession() {
+    if (!Native) return;
+
+    let exit: string | null = null;
+    try {
+        ({ exit, scope: lastScope } = await Native.sessionOpened());
+    } catch (error) {
+        logger.error("Failed to reach the desktop process", error);
+        return;
+    }
+
+    // O corpo inteiro vai no try porque ele roda num timer, e excecao dentro de um timer nao
+    // vira rejeicao que alguem la fora possa pegar: ela escapa. Basta o Discord renomear a
+    // loja do experimento para o videoIsBlocked estourar, e ai o plugin fica mudo, sem toast
+    // e sem a nova tentativa, em vez de dizer que nao conseguiu ler o veredito.
+    setTimeout(() => {
+        try {
+            if (videoIsBlocked()) {
+                logger.warn("O servidor continuou bloqueando video nesta sessao, saida do gateway:", exit);
+                retryBehindExit();
+                return;
+            }
+
+            // Avisar so depois do veredito. Avisar no CONNECTION_OPEN marcaria como boa uma
+            // saida que abriu o tunel e mesmo assim entregou uma sessao bloqueada, e o
+            // processo principal a ofereceria de novo no proximo boot.
+            Native.sessionWorked().catch(error => logger.error("Failed to reach the desktop process", error));
+
+            showToast(exit === null
+                ? "Go Live is unlocked on this session, with no exit in the way."
+                : `Go Live is unlocked. Only the gateway stays on ${exit}, everything else is direct.`,
+            Toasts.Type.SUCCESS);
+        } catch (error) {
+            logger.error("Failed to read the video guard verdict for this session", error);
+        }
+    }, VERDICT_DELAY_MS);
 }
 
 function ask(store: object, method: string, ...args: unknown[]) {
@@ -318,15 +327,20 @@ async function buildReport() {
     lines.push(`override instalado ${original !== undefined}`);
 
     lines.push("", "== configuracao ==");
-    const { proxy, voiceRegion, streamRegion, excludedCountries } = settings.store;
-    lines.push(`proxy "${proxy}" | regiao de call "${voiceRegion}" | regiao de stream "${streamRegion}" | paises fora "${excludedCountries}"`);
+    const { proxy, sessionRouting, voiceRegion, streamRegion, excludedCountries } = settings.store;
+    lines.push(`proxy "${proxy}" | roteamento "${sessionRouting}" | regiao de call "${voiceRegion}" | regiao de stream "${streamRegion}" | paises fora "${excludedCountries}"`);
 
     lines.push("", "== processo principal ==");
     if (!Native) {
         lines.push("indisponivel, o plugin esta rodando sem a parte desktop");
     } else {
+        // O escopo e o que o CONNECTION_OPEN devolveu, e nao uma pergunta nova: sessionOpened
+        // encolhe o escopo como efeito, e um diagnostico que mexe no roteamento estragaria
+        // justamente a sessao que a pessoa esta tentando descrever.
+        lines.push(`escopo na abertura da sessao: ${lastScope ?? "a sessao nao abriu com o plugin no ar"}`);
+
         try {
-            lines.push(`proxy no ar agora: ${await Native.getActiveProxy() ?? "nenhum"}`);
+            lines.push(`saida do gateway agora: ${await Native.getActiveProxy() ?? "nenhuma"}`);
             lines.push(await Native.getLog() || "sem registros");
         } catch (error) {
             lines.push(`nao consegui falar com o processo principal: ${error instanceof Error ? error.message : String(error)}`);
@@ -380,11 +394,11 @@ export default definePlugin({
 
     flux: {
         CONNECTION_OPEN() {
-            releaseProxy();
+            reportSession();
         },
 
         LOGOUT() {
-            startBypass();
+            Native?.sessionClosed().catch(error => logger.error("Failed to reach the desktop process", error));
         }
     },
 
@@ -394,6 +408,6 @@ export default definePlugin({
 
     stop() {
         restoreRegion();
-        releaseProxy();
+        Native?.shutdown().catch(error => logger.error("Failed to reach the desktop process", error));
     }
 });

--- a/goLiveBypass/native.ts
+++ b/goLiveBypass/native.ts
@@ -7,37 +7,69 @@
 import { NativeSettings, RendererSettings } from "@main/settings";
 import { app, IpcMainInvokeEvent, session } from "electron";
 import { request } from "https";
-import { connect, Socket } from "net";
+import { AddressInfo, connect, createServer as createSocksServer, Server as SocksServer, Socket } from "net";
 import { connect as connectTls } from "tls";
 
 const FREE_PROXY_API = "https://api.proxyscrape.com/v4/free-proxy-list/get?request=display_proxies&protocol=socks5&proxy_format=protocolipport&format=json&timeout=1500";
-const GEO_HOST = "ifconfig.co";
 const DISCORD_HOST = "discord.com";
+
+// O trace da Cloudflare responde em ~200 bytes e ja diz tudo que precisamos saber de uma
+// candidata: que o tunel SOCKS abre, que o TLS fecha com certificado valido (proxy que
+// intercepta cai aqui), que veio HTTP 200, e de que pais ela sai. A validacao antiga
+// gastava duas conexoes, uma no discord.com e outra no ifconfig.co, para descobrir o mesmo.
+const TRACE_HOST = "cloudflare.com";
+const TRACE_PATH = "/cdn-cgi/trace";
+
+const GATEWAY_HOSTS = ["gateway.discord.gg", "remote-auth-gateway.discord.gg"];
+const LOGIN_HOSTS = ["discord.com", "canary.discord.com", "ptb.discord.com"];
 
 const MAX_LIST_BYTES = 1024 * 1024;
 const PROBE_TIMEOUT_MS = 6000;
-const PARALLEL_PROBES = 10;
-const MAX_CANDIDATES = 40;
+
+// Prazo curto para as checagens que acontecem no caminho da abertura: a saida do campo Proxy
+// e as guardadas no pote. Todas elas ou respondem rapido ou nao servem, e cada segundo gasto
+// aqui sai do orcamento que segura o gateway.
+const WARM_PROBE_TIMEOUT_MS = 2500;
+
+const PARALLEL_PROBES = 12;
+const MAX_CANDIDATES = 48;
 const MIN_UPTIME = 90;
 const MAX_LISTED_TIMEOUT = 1500;
-const SESSION_DEADLINE_MS = 120_000;
+
 // Portas SOCKS de clientes Tor, em ordem de preferencia. A 9052 vem primeiro porque e a que
 // o instalador configura com bridge meek: ela atravessa rede censurada, que e exatamente o
 // cenario de quem precisa deste plugin. As outras sao Tor Browser, daemon e Brave, que podem
 // estar sem bridge nenhuma.
 const TOR_PORTS = [9052, 9150, 9050, 9250];
 const TOR_PORT_TIMEOUT_MS = 400;
+
+const POOL_SIZE = 5;
+const POOL_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
 const MAX_LOG_LINES = 200;
 const MAX_RETRIES = 2;
-const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
-const BOOT_PROBE_TIMEOUT_MS = 2500;
+
+// Quanto tempo o gateway fica segurado enquanto a saida e escolhida. Estourou, ele sai
+// direto: perde-se o Go Live daquela sessao, nunca o Discord.
+const STALL_BUDGET_MS = 12_000;
+
+// Orcamentos do trafego vivo, bem menores que os do teste de candidata. Uma saida agonizante
+// que demora seis segundos para falhar e pior que uma morta: ela faz o Chromium desistir do
+// roteador inteiro.
+const RELAY_TUNNEL_TIMEOUT_MS = 2500;
+const RELAY_DIRECT_TIMEOUT_MS = 8000;
+
 const INTERCEPTING_PORTS = new Set([4145]);
-
 const PROXY_RULES_RE = /^(socks5|https?):\/\/([a-z0-9.-]{1,253}):(\d{1,5})$/;
-const PROXY_BYPASS_RULES = "cdn.discordapp.com;*.discordapp.net;*.discord.media;<local>";
 
-let appliedProxy: string | null = null;
-let deadline: ReturnType<typeof setTimeout> | undefined;
+export type Scope = "login" | "gateway" | "off";
+
+interface PoolEntry {
+    proxy: string;
+    country: string;
+    ms: number;
+    at: number;
+}
 
 const history: string[] = [];
 
@@ -59,158 +91,93 @@ function parseProxy(proxyRules: string) {
     return { scheme: match[1], host: match[2], port };
 }
 
-function markBoot(pending: boolean) {
-    NativeSettings.store.plugins.GoLiveBypass ??= {};
-    NativeSettings.store.plugins.GoLiveBypass.bootPending = pending;
+function pluginSettings() {
+    return RendererSettings.plain.plugins?.GoLiveBypass;
 }
 
-function bootWasPending() {
-    return NativeSettings.plain.plugins?.GoLiveBypass?.bootPending === true;
+function pluginEnabled() {
+    return pluginSettings()?.enabled === true;
 }
 
-function listening(port: number, timeoutMs: number): Promise<boolean> {
-    return new Promise(resolve => {
-        const socket = connect({ host: "127.0.0.1", port });
-        const finish = (open: boolean) => {
-            socket.destroy();
-            resolve(open);
-        };
+// Tres respostas diferentes, e antes elas estavam misturadas numa so: o campo esta vazio
+// (procure sozinho), o campo tem um endereco bom (use este), o campo tem lixo (nao invente
+// uma saida que a pessoa nao escolheu).
+function manualProxy(): { proxy: string; } | "auto" | "invalid" {
+    const proxy = pluginSettings()?.proxy;
+    if (typeof proxy !== "string" || proxy.trim() === "") return "auto";
 
-        socket.setTimeout(timeoutMs, () => finish(false));
-        socket.once("connect", () => finish(true));
-        socket.on("error", () => finish(false));
-    });
-}
-
-function readCachedProxy() {
-    const cache: unknown = NativeSettings.plain.plugins?.GoLiveBypass?.verifiedProxy;
-    if (typeof cache !== "object" || cache === null) return null;
-
-    const { proxy, at } = cache as { proxy?: unknown; at?: unknown; };
-    if (typeof proxy !== "string" || parseProxy(proxy) === null) return null;
-    if (typeof at !== "number" || Date.now() - at > CACHE_MAX_AGE_MS) return null;
-
-    return proxy;
-}
-
-function storeCachedProxy(proxy: string) {
-    NativeSettings.store.plugins.GoLiveBypass ??= {};
-    NativeSettings.store.plugins.GoLiveBypass.verifiedProxy = { proxy, at: Date.now() };
+    const trimmed = proxy.trim();
+    return parseProxy(trimmed) === null ? "invalid" : { proxy: trimmed };
 }
 
 function excludedCountries() {
-    const raw: unknown = RendererSettings.plain.plugins?.GoLiveBypass?.excludedCountries;
+    const raw: unknown = pluginSettings()?.excludedCountries;
     const codes = typeof raw === "string" ? raw.split(",") : ["BR"];
 
     return new Set(codes.map(code => code.trim().toUpperCase()).filter(code => /^[A-Z]{2}$/.test(code)));
 }
 
-async function bootProxy() {
-    const manual = manualProxy();
-    if (manual === null) {
-        log("o proxy do campo Proxy nao e valido, nada foi aplicado");
-        return "";
-    }
-    if (manual !== "") {
-        // Sem testar, um proxy fora do ar viraria conexao direta pelo fallback direct:// e o
-        // bypass falharia em silencio, que foi exatamente o que aconteceu com o Tor fechado.
-        const started = Date.now();
-        if (await probe(manual, BOOT_PROBE_TIMEOUT_MS) !== null) {
-            log(`seu proxy respondeu em ${Date.now() - started}ms: ${manual}`);
-            return manual;
-        }
-
-        log(`seu proxy nao respondeu: ${manual}`);
-        log("se for Tor, ele precisa estar aberto ANTES do Discord. Procurando alternativa.");
-    }
-
-    for (const port of TOR_PORTS) {
-        const tor = `socks5://127.0.0.1:${port}`;
-        if (!await listening(port, TOR_PORT_TIMEOUT_MS)) continue;
-
-        if (await probe(tor, BOOT_PROBE_TIMEOUT_MS) !== null) {
-            log(`Tor local encontrado na porta ${port}`);
-            return tor;
-        }
-        log(`porta ${port} aberta mas nao respondeu como proxy, ignorando`);
-    }
-
-    // Sem Tor local a escolha de uma proxy gratuita levaria dezenas de segundos, e o gateway
-    // conecta antes disso. Reaproveitar a ultima que funcionou resolve, desde que ela seja
-    // testada de novo agora: aplicar uma proxy morta as cegas foi o que travava o Discord.
-    const cached = readCachedProxy();
-    if (cached !== null) {
-        const started = Date.now();
-        if (await probe(cached, BOOT_PROBE_TIMEOUT_MS) !== null) {
-            log(`proxy guardada revalidada em ${Date.now() - started}ms: ${cached}`);
-            return cached;
-        }
-        log("a proxy guardada morreu, procurando outra");
-    }
-
-    log("procurando uma proxy nova, isso demora e o gateway pode conectar antes");
-    const picked = await sharedFreeProxy(excludedCountries());
-    log(picked === null ? "nenhuma proxy passou nos testes" : `proxy escolhida: ${picked}`);
-
-    return picked ?? "";
+// O renderer manda a propria lista nas chamadas que ele inicia. O nome do parametro cobre o
+// da funcao acima dentro daquelas funcoes, entao a leitura precisa de nome proprio.
+function requestedCountries(raw: unknown) {
+    return new Set(
+        typeof raw === "string"
+            ? raw.split(",").map(code => code.trim().toUpperCase()).filter(code => /^[A-Z]{2}$/.test(code))
+            : []
+    );
 }
 
-function manualProxy() {
-    const settings = RendererSettings.plain.plugins?.GoLiveBypass;
-    if (settings?.enabled !== true) return null;
-
-    const { proxy } = settings;
-    if (typeof proxy !== "string" || proxy.trim() === "") return "";
-
-    // Invalido nao pode virar "vazio": cair na lista gratuita mandaria a sessao para um proxy
-    // que a pessoa nunca escolheu.
-    return parseProxy(proxy.trim()) === null ? null : proxy.trim();
+function routesLogin() {
+    return pluginSettings()?.sessionRouting === "login";
 }
 
-async function apply(proxy: string) {
+function readPool(): PoolEntry[] {
+    let stored: unknown;
     try {
-        await session.defaultSession.setProxy({
-            proxyRules: `${proxy},direct://`,
-            proxyBypassRules: PROXY_BYPASS_RULES
-        });
-        await session.defaultSession.closeAllConnections();
+        stored = NativeSettings.plain.plugins?.GoLiveBypass?.pool;
     } catch {
-        return false;
+        return [];
     }
 
-    appliedProxy = proxy;
-    markBoot(true);
-    log(`proxy aplicado: ${proxy}`);
+    if (!Array.isArray(stored)) return [];
 
-    clearTimeout(deadline);
-    deadline = setTimeout(() => {
-        log("a sessao nao abriu no prazo, soltando o proxy para nao travar o Discord");
-        clear();
-    }, SESSION_DEADLINE_MS);
-    return true;
+    return stored.filter((entry): entry is PoolEntry => {
+        if (typeof entry !== "object" || entry === null) return false;
+
+        const { proxy, country, ms, at } = entry as Partial<PoolEntry>;
+        return typeof proxy === "string" && parseProxy(proxy) !== null
+            && typeof country === "string" && typeof ms === "number"
+            && typeof at === "number" && Date.now() - at < POOL_MAX_AGE_MS;
+    });
 }
 
-async function clear() {
-    clearTimeout(deadline);
-    deadline = undefined;
-    appliedProxy = null;
-    markBoot(false);
-
-    log("proxy liberado, so o gateway continua nele");
-
+// Duas instancias do Discord dividem este arquivo, entao gravar pode falhar por disputa.
+// Perder o pote custa uma busca a mais no proximo boot. Deixar a excecao subir custava o
+// processo principal.
+function writePool(entries: PoolEntry[]) {
     try {
-        // "system" e o que uma sessao intocada usa. Voltar para "direct" arrancaria o proxy
-        // do sistema de quem esta atras de PAC, VPN ou proxy corporativo.
-        await session.defaultSession.setProxy({ mode: "system" });
-        await session.defaultSession.closeAllConnections();
+        NativeSettings.store.plugins.GoLiveBypass ??= {};
+        NativeSettings.store.plugins.GoLiveBypass.pool = entries
+            .sort((a, b) => a.ms - b.ms)
+            .slice(0, POOL_SIZE);
     } catch {
-        return false;
+        // sem pote guardado, o proximo boot procura de novo
     }
-    return true;
 }
 
-function readReply(socket: Socket, size: (buffer: Buffer) => number, done: (reply: Buffer | null) => void) {
+function readFrame(socket: Socket, size: (buffer: Buffer) => number, done: (frame: Buffer | null) => void) {
     const chunks: Buffer[] = [];
+    let settled = false;
+
+    const finish = (frame: Buffer | null) => {
+        if (settled) return;
+        settled = true;
+        socket.off("data", onData);
+        socket.off("close", onClose);
+        done(frame);
+    };
+
+    const onClose = () => finish(null);
 
     const onData = (chunk: Buffer) => {
         chunks.push(chunk);
@@ -218,26 +185,28 @@ function readReply(socket: Socket, size: (buffer: Buffer) => number, done: (repl
         const wanted = size(buffer);
         if (wanted < 0 || buffer.length < wanted) return;
 
-        socket.off("data", onData);
         socket.pause();
         if (buffer.length > wanted) socket.unshift(buffer.subarray(wanted));
-        done(buffer.subarray(0, wanted));
+        finish(buffer.subarray(0, wanted));
     };
 
     socket.on("data", onData);
+    socket.on("close", onClose);
     socket.resume();
 }
 
+function socksReplySize(buffer: Buffer) {
+    if (buffer.length < 4) return -1;
+    if (buffer[3] === 1) return 10;
+    if (buffer[3] === 4) return 22;
+    return buffer.length < 5 ? -1 : 7 + buffer[4];
+}
+
 function negotiateSocks5(socket: Socket, host: string, port: number, done: (ok: boolean) => void) {
-    readReply(socket, buffer => buffer.length < 2 ? -1 : 2, greeting => {
+    readFrame(socket, buffer => buffer.length < 2 ? -1 : 2, greeting => {
         if (greeting === null || greeting[1] !== 0) return done(false);
 
-        readReply(socket, buffer => {
-            if (buffer.length < 4) return -1;
-            if (buffer[3] === 1) return 10;
-            if (buffer[3] === 4) return 22;
-            return buffer.length < 5 ? -1 : 7 + buffer[4];
-        }, reply => done(reply !== null && reply[1] === 0));
+        readFrame(socket, socksReplySize, reply => done(reply !== null && reply[1] === 0));
 
         const target = Buffer.from(host, "latin1");
         socket.write(Buffer.concat([
@@ -251,12 +220,33 @@ function negotiateSocks5(socket: Socket, host: string, port: number, done: (ok: 
 }
 
 function negotiateConnect(socket: Socket, host: string, port: number, done: (ok: boolean) => void) {
-    readReply(socket, buffer => {
+    readFrame(socket, buffer => {
         const end = buffer.indexOf("\r\n\r\n");
         return end < 0 ? -1 : end + 4;
     }, reply => done(reply !== null && /^HTTP\/1\.[01] 200/.test(reply.toString("latin1"))));
 
     socket.write(`CONNECT ${host}:${port} HTTP/1.1\r\nHost: ${host}:${port}\r\n\r\n`);
+}
+
+function openDirect(host: string, port: number, timeoutMs: number): Promise<Socket | null> {
+    return new Promise(resolve => {
+        const socket = connect({ host, port });
+        let settled = false;
+
+        const finish = (result: Socket | null) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(guard);
+            socket.setTimeout(0);
+            if (result === null) socket.destroy();
+            resolve(result);
+        };
+
+        const guard = setTimeout(() => finish(null), timeoutMs);
+        socket.setTimeout(timeoutMs, () => finish(null));
+        socket.on("error", () => finish(null));
+        socket.once("connect", () => finish(socket));
+    });
 }
 
 function openTunnel(proxy: string, host: string, port: number, timeoutMs = PROBE_TIMEOUT_MS): Promise<Socket | null> {
@@ -315,124 +305,18 @@ function readOverTls(socket: Socket, host: string, path: string, timeoutMs = PRO
     });
 }
 
-async function probe(proxy: string, timeoutMs = PROBE_TIMEOUT_MS) {
-    const started = Date.now();
-
-    const socket = await openTunnel(proxy, DISCORD_HOST, 443, timeoutMs);
-    if (socket === null) return null;
-
-    const response = await readOverTls(socket, DISCORD_HOST, "/api/v9/gateway", timeoutMs);
-    if (response === null || !response.startsWith("HTTP/1.1 200")) return null;
-
-    return { proxy, ms: Date.now() - started };
-}
-
-async function exitCountry(proxy: string) {
-    const socket = await openTunnel(proxy, GEO_HOST, 443);
-    if (socket === null) return null;
-
-    const response = await readOverTls(socket, GEO_HOST, "/json");
-    if (response === null) return null;
-
-    const match = /"country_iso"\s*:\s*"([A-Za-z]{2})"|"country(?:Code)?"\s*:\s*"([A-Za-z]{2})"/.exec(response);
-    if (match === null) return null;
-
-    return (match[1] ?? match[2]).toUpperCase();
-}
-
-async function accepts(proxy: string, excluded: Set<string>) {
-    const country = await exitCountry(proxy);
-    return country !== null && !excluded.has(country);
-}
-
-function rankFreeProxies(body: string, excluded: Set<string>) {
-    const data: unknown = JSON.parse(body);
-    const { proxies } = data as { proxies?: unknown };
-    if (!Array.isArray(proxies)) return [];
-
-    const usable: { proxy: string; uptime: number; timeout: number; }[] = [];
-
-    for (const item of proxies) {
-        if (typeof item !== "object" || item === null) continue;
-
-        const entry = item as {
-            proxy?: unknown;
-            alive?: unknown;
-            uptime?: unknown;
-            timeout?: unknown;
-            ip_data?: { countryCode?: unknown; };
+function listening(port: number, timeoutMs: number): Promise<boolean> {
+    return new Promise(resolve => {
+        const socket = connect({ host: "127.0.0.1", port });
+        const finish = (open: boolean) => {
+            socket.destroy();
+            resolve(open);
         };
 
-        if (typeof entry.proxy !== "string" || entry.alive !== true) continue;
-
-        const parsed = parseProxy(entry.proxy);
-        if (parsed === null || INTERCEPTING_PORTS.has(parsed.port)) continue;
-
-        const uptime = typeof entry.uptime === "number" ? entry.uptime : 0;
-        const timeout = typeof entry.timeout === "number" ? entry.timeout : MAX_LISTED_TIMEOUT;
-        if (uptime < MIN_UPTIME || timeout > MAX_LISTED_TIMEOUT) continue;
-
-        const country = typeof entry.ip_data?.countryCode === "string" ? entry.ip_data.countryCode.toUpperCase() : "";
-        if (excluded.has(country)) continue;
-
-        usable.push({ proxy: entry.proxy, uptime, timeout });
-    }
-
-    return usable
-        .sort((a, b) => b.uptime - a.uptime || a.timeout - b.timeout)
-        .slice(0, MAX_CANDIDATES)
-        .map(entry => entry.proxy);
-}
-
-// O boot e o pedido do renderer procuram proxy ao mesmo tempo. Duas buscas paralelas disputam
-// a mesma banda e dobram o tempo ate a primeira proxy ficar pronta, que e exatamente a janela
-// em que o gateway conecta sem protecao. Quem chegar depois espera a busca que ja esta correndo.
-let hunting: Promise<string | null> | null = null;
-
-function sharedFreeProxy(excluded: Set<string>) {
-    hunting ??= pickFreeProxy(excluded).finally(() => { hunting = null; });
-    return hunting;
-}
-
-async function pickFreeProxy(excluded: Set<string>) {
-    let candidates: string[];
-    try {
-        candidates = rankFreeProxies(await downloadText(FREE_PROXY_API), excluded);
-    } catch {
-        return null;
-    }
-
-    log(`${candidates.length} candidatas depois do ranqueamento`);
-
-    for (let i = 0; i < candidates.length; i += PARALLEL_PROBES) {
-        // map passa (item, indice, array), entao .map(probe) mandava o indice como timeout
-        // e todas as candidatas estouravam o prazo em milissegundos.
-        const batch = await Promise.all(candidates.slice(i, i + PARALLEL_PROBES).map(candidate => probe(candidate)));
-        const working = batch
-            .filter((result): result is { proxy: string; ms: number; } => result !== null)
-            .sort((a, b) => a.ms - b.ms);
-
-        for (const candidate of working) {
-            const country = await exitCountry(candidate.proxy);
-            if (country !== null && !excluded.has(country)) {
-                log(`${candidate.proxy} passou: ${candidate.ms}ms, saida em ${country}`);
-                storeCachedProxy(candidate.proxy);
-                return candidate.proxy;
-            }
-            log(`${candidate.proxy} recusada: saida em ${country ?? "pais desconhecido"}`);
-        }
-    }
-
-    return null;
-}
-
-async function detectTor(excluded: Set<string>) {
-    for (const port of TOR_PORTS) {
-        const proxy = `socks5://127.0.0.1:${port}`;
-        if (await probe(proxy) !== null && await accepts(proxy, excluded)) return proxy;
-    }
-
-    return null;
+        socket.setTimeout(timeoutMs, () => finish(false));
+        socket.once("connect", () => finish(true));
+        socket.on("error", () => finish(false));
+    });
 }
 
 function downloadText(url: string): Promise<string> {
@@ -475,57 +359,557 @@ function downloadText(url: string): Promise<string> {
     });
 }
 
-app.whenReady().then(async () => {
-    app.on("browser-window-created", (_event, win) => {
-        win.webContents.on("did-fail-load", (_failed, code, _description, _url, isMainFrame) => {
-            if (isMainFrame && code !== -3 && appliedProxy !== null) {
-                log(`a pagina falhou ao carregar (${code}), voltando para conexao direta`);
-                clear();
-            }
+async function measure(proxy: string, timeoutMs = PROBE_TIMEOUT_MS) {
+    const started = Date.now();
+
+    const socket = await openTunnel(proxy, TRACE_HOST, 443, timeoutMs);
+    if (socket === null) return null;
+
+    const response = await readOverTls(socket, TRACE_HOST, TRACE_PATH, timeoutMs);
+    if (response === null || !/^HTTP\/1\.[01] 200/.test(response)) return null;
+
+    const country = /(?:^|\n)loc=([A-Za-z]{2})/.exec(response);
+    if (country === null) return null;
+
+    const ip = /(?:^|\n)ip=(\S+)/.exec(response);
+
+    return { proxy, country: country[1].toUpperCase(), ip: ip?.[1] ?? "", ms: Date.now() - started };
+}
+
+// Todas as candidatas do lote andam juntas, e a primeira que responder bem ganha. Antes o
+// teste de pais rodava uma candidata por vez depois do lote inteiro terminar, o que sozinho
+// podia somar um minuto.
+function firstUsable(candidates: string[], excluded: Set<string>, timeoutMs: number) {
+    return new Promise<PoolEntry | null>(resolve => {
+        let pending = candidates.length;
+        if (pending === 0) return resolve(null);
+
+        let settled = false;
+
+        // O prazo vai escrito na chamada de proposito. Um candidates.map(measure) parece
+        // igual e nao e: map passa (item, indice, array), entao o indice cairia em timeoutMs
+        // e a candidata numero zero teria zero milissegundo para responder.
+        for (const candidate of candidates) {
+            measure(candidate, timeoutMs).then(result => {
+                if (!settled && result !== null && !excluded.has(result.country)) {
+                    settled = true;
+                    log(`${result.proxy} passou: ${result.ms}ms, saida em ${result.country}`);
+                    resolve({ proxy: result.proxy, country: result.country, ms: result.ms, at: Date.now() });
+                    return;
+                }
+
+                if (result !== null && excluded.has(result.country)) log(`${result.proxy} recusada: saida em ${result.country}`);
+                if (--pending === 0 && !settled) resolve(null);
+            });
+        }
+    });
+}
+
+async function torExit(excluded: Set<string>, timeoutMs: number) {
+    for (const port of TOR_PORTS) {
+        const proxy = `socks5://127.0.0.1:${port}`;
+        if (!await listening(port, TOR_PORT_TIMEOUT_MS)) continue;
+
+        const found = await firstUsable([proxy], excluded, timeoutMs);
+        if (found !== null) {
+            log(`Tor local encontrado na porta ${port}`);
+            return found;
+        }
+
+        log(`porta ${port} aberta mas nao respondeu como proxy, ignorando`);
+    }
+
+    return null;
+}
+
+function rankFreeProxies(body: string, excluded: Set<string>) {
+    const data: unknown = JSON.parse(body);
+    const { proxies } = data as { proxies?: unknown; };
+    if (!Array.isArray(proxies)) return [];
+
+    const usable: { proxy: string; uptime: number; timeout: number; }[] = [];
+
+    for (const item of proxies) {
+        if (typeof item !== "object" || item === null) continue;
+
+        const entry = item as {
+            proxy?: unknown;
+            alive?: unknown;
+            uptime?: unknown;
+            timeout?: unknown;
+            ip_data?: { countryCode?: unknown; };
+        };
+
+        if (typeof entry.proxy !== "string" || entry.alive !== true) continue;
+
+        const parsed = parseProxy(entry.proxy);
+        if (parsed === null || INTERCEPTING_PORTS.has(parsed.port)) continue;
+
+        const uptime = typeof entry.uptime === "number" ? entry.uptime : 0;
+        const timeout = typeof entry.timeout === "number" ? entry.timeout : MAX_LISTED_TIMEOUT;
+        if (uptime < MIN_UPTIME || timeout > MAX_LISTED_TIMEOUT) continue;
+
+        const country = typeof entry.ip_data?.countryCode === "string" ? entry.ip_data.countryCode.toUpperCase() : "";
+        if (excluded.has(country)) continue;
+
+        usable.push({ proxy: entry.proxy, uptime, timeout });
+    }
+
+    return usable
+        .sort((a, b) => b.uptime - a.uptime || a.timeout - b.timeout)
+        .slice(0, MAX_CANDIDATES)
+        .map(entry => entry.proxy);
+}
+
+async function freeExit(excluded: Set<string>, want: number) {
+    let candidates: string[];
+    try {
+        candidates = rankFreeProxies(await downloadText(FREE_PROXY_API), excluded);
+    } catch {
+        return [];
+    }
+
+    log(`${candidates.length} candidatas depois do ranqueamento`);
+
+    const found: PoolEntry[] = [];
+
+    for (let i = 0; i < candidates.length && found.length < want; i += PARALLEL_PROBES) {
+        const batch = candidates.slice(i, i + PARALLEL_PROBES);
+        const winner = await firstUsable(batch, excluded, PROBE_TIMEOUT_MS);
+        if (winner !== null) found.push(winner);
+    }
+
+    return found;
+}
+
+// Reabastecer o pote e uma escolha nova disparada por uma saida que morreu podem correr ao
+// mesmo tempo. Duas buscas paralelas disputam a mesma banda e dobram o tempo ate a primeira
+// saida ficar pronta, que e exatamente a janela em que o gateway conecta sem protecao. Quem
+// chegar depois espera a busca que ja esta correndo.
+let hunting: Promise<PoolEntry[]> | null = null;
+
+function sharedFreeExit(excluded: Set<string>, want: number) {
+    hunting ??= freeExit(excluded, want).finally(() => { hunting = null; });
+    return hunting;
+}
+
+let exit: string | null = null;
+let exitSettled = false;
+let waiting: ((value: string | null) => void)[] = [];
+
+function settleExit(value: string | null) {
+    exit = value;
+    exitSettled = true;
+
+    const pending = waiting;
+    waiting = [];
+    for (const resume of pending) resume(value);
+}
+
+// O gateway chega aqui antes de existir saida escolhida, e e exatamente isso que a versao
+// anterior nao conseguia fazer: como o proxy era aplicado na sessao inteira, escolher tinha
+// que acontecer antes do app subir, e o boot inteiro parava de 8 a 23 segundos. Segurando
+// so este socket, o Discord carrega na velocidade normal enquanto a busca acontece.
+function currentExit(): Promise<string | null> {
+    if (exitSettled) return Promise.resolve(exit);
+
+    return new Promise(resolve => {
+        const resume = (value: string | null) => {
+            clearTimeout(guard);
+            resolve(value);
+        };
+
+        const guard = setTimeout(() => {
+            waiting = waiting.filter(entry => entry !== resume);
+            log("nenhuma saida ficou pronta a tempo, esta conexao vai direta");
+            resolve(null);
+        }, STALL_BUDGET_MS);
+
+        waiting.push(resume);
+    });
+}
+
+// Saida que falhou no trafego vivo sai do pote e a busca recomeca. Ate a nova chegar o
+// roteador manda direto, que custa o Go Live e nunca a conexao.
+function dropExit(dead: string, excluded?: Set<string>) {
+    if (exit !== dead) return;
+
+    log(`${dead} parou de entregar, tirando do pote e procurando outra`);
+    writePool(readPool().filter(entry => entry.proxy !== dead));
+    exit = null;
+    chooseExit(excluded);
+}
+
+// Uma escolha por vez, e quem pedir no meio recebe a que ja esta correndo em vez de comecar
+// outra. Guardar a promessa em vez de um booleano importa: o retryWithProxy precisa esperar
+// o resultado antes de recarregar a janela, e com um booleano ele veria "ja tem alguem
+// escolhendo" e recarregaria sem saida nenhuma, queimando uma tentativa a toa.
+let choosing: Promise<void> | null = null;
+
+function chooseExit(excluded?: Set<string>) {
+    choosing ??= runChoice(excluded ?? excludedCountries()).finally(() => { choosing = null; });
+    return choosing;
+}
+
+// Nada aqui pode escapar. Este plugin roda no processo principal do Discord, e no Node
+// atual uma promessa rejeitada sem tratamento derruba o processo inteiro: o Discord some
+// da tela, ou pior, sobra a janela presa na tela de conexao sem processo principal atras.
+// Aconteceu ao subir duas instancias, que disputaram o mesmo native-settings.json.
+async function runChoice(excluded: Set<string>) {
+    try {
+        await pickExit(excluded);
+    } catch {
+        // Quem ja escolheu nao perde a saida por causa de um erro que veio depois: sem esta
+        // condicao um tropeco no reabastecimento apagaria a saida que esta funcionando.
+        if (!exitSettled) settleExit(null);
+    }
+}
+
+async function pickExit(excluded: Set<string>) {
+    const manual = manualProxy();
+    if (manual === "invalid") {
+        log("o endereco do campo Proxy nao e valido, nenhuma saida foi usada");
+        return settleExit(null);
+    }
+
+    if (manual !== "auto") {
+        // Sem testar, uma saida fora do ar viraria conexao direta dentro do roteador e o
+        // bypass falharia em silencio, que foi exatamente o que aconteceu com o Tor fechado.
+        const started = Date.now();
+        if (await measure(manual.proxy, WARM_PROBE_TIMEOUT_MS) !== null) {
+            log(`seu proxy respondeu em ${Date.now() - started}ms: ${manual.proxy}`);
+            return settleExit(manual.proxy);
+        }
+
+        log(`seu proxy nao respondeu: ${manual.proxy}`);
+        log("se for Tor, ele precisa estar aberto ANTES do Discord. Procurando alternativa.");
+    }
+
+    return autoExit(excluded);
+}
+
+async function autoExit(excluded: Set<string>) {
+    const pool = readPool();
+    if (pool.length > 0) {
+        const warm = await firstUsable(pool.map(entry => entry.proxy), excluded, WARM_PROBE_TIMEOUT_MS);
+        if (warm !== null) {
+            log(`saida guardada revalidada em ${warm.ms}ms: ${warm.proxy}`);
+            settleExit(warm.proxy);
+
+            // Solta sem esperar: o pote so serve para o proximo boot, e prender a escolha
+            // ate ele encher deixaria uma saida morta no meio da sessao sem substituta,
+            // porque quem descarta a saida morta encontraria a escolha ainda ocupada.
+            refillPool(excluded, warm).catch(() => { });
+            return;
+        }
+
+        log("as saidas guardadas morreram, procurando outra");
+    }
+
+    const tor = await torExit(excluded, PROBE_TIMEOUT_MS);
+    if (tor !== null) return settleExit(tor.proxy);
+
+    log(`procurando uma saida nova, o gateway fica segurado por ate ${Math.round(STALL_BUDGET_MS / 1000)}s`);
+    const [first] = await sharedFreeExit(excluded, 1);
+    log(first === undefined ? "nenhuma saida passou nos testes" : `saida escolhida: ${first.proxy}`);
+
+    settleExit(first?.proxy ?? null);
+    if (first !== undefined) writePool([first]);
+}
+
+// A busca cara acontece com a sessao ja aberta, para o proximo boot ter opcao pronta. E a
+// diferenca entre abrir o Discord em dois segundos e esperar meio minuto por uma lista.
+// Vale tambem quando o campo Proxy esta preenchido mas morto: a essa altura quem esta
+// carregando o gateway e uma saida encontrada, entao guardar as outras e o mesmo ganho.
+async function refillPool(excluded: Set<string>, keep: PoolEntry) {
+    try {
+        const found = await sharedFreeExit(excluded, POOL_SIZE);
+        writePool([keep, ...found.filter(entry => entry.proxy !== keep.proxy)]);
+        log(`pote guardado com ${Math.min(found.length + 1, POOL_SIZE)} saida(s)`);
+    } catch {
+        writePool([keep]);
+    }
+}
+
+let socks: SocksServer | undefined;
+let scope: Scope = "off";
+let fallbackRule = "DIRECT";
+
+function refuse(client: Socket) {
+    if (!client.destroyed) client.write(Buffer.from([5, 5, 0, 1, 0, 0, 0, 0, 0, 0]));
+    client.destroy();
+}
+
+function readTarget(request: Buffer) {
+    if (request[3] === 1) {
+        return { host: Array.from(request.subarray(4, 8)).join("."), port: request.readUInt16BE(8) };
+    }
+
+    if (request[3] === 3) {
+        const size = request[4];
+        return { host: request.subarray(5, 5 + size).toString("latin1"), port: request.readUInt16BE(5 + size) };
+    }
+
+    return null;
+}
+
+function serveSocks(client: Socket) {
+    client.on("error", () => client.destroy());
+
+    readFrame(client, buffer => buffer.length < 2 ? -1 : 2 + buffer[1], greeting => {
+        if (greeting === null || greeting[0] !== 5) return client.destroy();
+        client.write(Buffer.from([5, 0]));
+
+        readFrame(client, socksReplySize, request => {
+            // Cada conexao e isolada: o que der errado aqui fecha este socket e mais nada.
+            // Sem o catch, um erro em qualquer await abaixo viraria rejeicao nao tratada e
+            // levaria junto o processo principal do Discord.
+            serveRequest(client, request).catch(() => client.destroy());
         });
     });
+}
 
-    if (bootWasPending()) {
-        markBoot(false);
-        log("a abertura anterior nao terminou, entao nao vou aplicar proxy desta vez");
+async function serveRequest(client: Socket, request: Buffer | null) {
+    if (request === null || request[0] !== 5 || request[1] !== 1) return client.destroy();
+
+    const target = readTarget(request);
+    if (target === null) return refuse(client);
+
+    // Sucesso respondido agora, antes de saber por onde vamos sair, e isso e deliberado. O
+    // Chromium mantem uma lista de proxies ruins: basta uma resposta lenta ou negativa para
+    // ele parar de usar este roteador e mandar tudo direto, sem avisar. Foi o que aconteceu,
+    // com o relay de pe e saudavel e nenhuma conexao passando por ele. Respondendo na hora
+    // ele nunca tem motivo para desconfiar, e uma saida que falhe vira uma conexao fechada,
+    // que e problema do destino e nao do proxy. O socket continua pausado pelo readFrame,
+    // entao nada que o cliente mandar se perde ate o pipe comecar.
+    client.write(Buffer.from([5, 0, 0, 1, 0, 0, 0, 0, 0, 0]));
+
+    const through = await currentExit();
+    if (client.destroyed) return;
+
+    let upstream = through === null
+        ? await openDirect(target.host, target.port, RELAY_DIRECT_TIMEOUT_MS)
+        : await openTunnel(through, target.host, target.port, RELAY_TUNNEL_TIMEOUT_MS);
+
+    // Saida que nao entrega e descartada na hora, senao toda conexao seguinte paga o mesmo
+    // tempo de espera antes de cair para direto.
+    if (upstream === null && through !== null) {
+        dropExit(through);
+        upstream = await openDirect(target.host, target.port, RELAY_DIRECT_TIMEOUT_MS);
+    }
+
+    if (upstream === null) return client.destroy();
+
+    if (client.destroyed) {
+        upstream.destroy();
         return;
     }
 
-    const proxy = await bootProxy();
-    if (proxy) apply(proxy);
-});
+    upstream.on("error", () => client.destroy());
+    client.on("close", () => upstream.destroy());
+    upstream.on("close", () => client.destroy());
 
-function requestedCountries(raw: unknown) {
-    return new Set(
-        typeof raw === "string"
-            ? raw.split(",").map(code => code.trim().toUpperCase()).filter(code => /^[A-Z]{2}$/.test(code))
-            : []
-    );
+    upstream.pipe(client);
+    client.pipe(upstream);
 }
 
-export async function enable(_: IpcMainInvokeEvent, excludedCountries: unknown) {
-    if (appliedProxy !== null) return { success: true as const, proxy: appliedProxy };
+function pacScript(socksPort: number, routed: string[]) {
+    const list = routed.map(host => `"${host}"`).join(",");
 
-    const excluded = requestedCountries(excludedCountries);
-
-    const manual = manualProxy();
-    if (manual === null) return { success: false as const, error: "O endereco no campo Proxy nao e valido. Use socks5://host:porta." };
-
-    const proxy = manual || await detectTor(excluded) || await sharedFreeProxy(excluded);
-    if (proxy === null || proxy === "")
-        return { success: false as const, error: "No proxy could carry a real request to Discord, so the connection stays direct." };
-
-    return await apply(proxy)
-        ? { success: true as const, proxy }
-        : { success: false as const, error: "Electron refused the proxy." };
+    // O host roteado sai pelo roteador e ponto, sem alternativa depois do ponto e virgula.
+    // Ter uma custou uma sessao inteira: uma saida gratuita falhou uma vez, o Chromium
+    // marcou o SOCKS local como ruim, e a partir dali mandou tudo pela alternativa sem
+    // avisar ninguem. PAC servido, roteador escutando, e nenhuma conexao passando por ele.
+    // A rede de seguranca real e outra: o roteador nunca recusa por causa da saida, ele
+    // mesmo cai para conexao direta. Ela vive dentro do processo, onde da para medir, e nao
+    // numa regra do Chromium que decide sozinho e nao conta.
+    // Quem nao esta na lista continua com a regra que o sistema ja usava, entao proxy
+    // corporativo ou PAC da empresa seguem valendo para o resto do Discord.
+    return `var routed = [${list}];\n`
+        + "function FindProxyForURL(url, host) {\n"
+        + "    for (var i = 0; i < routed.length; i++)\n"
+        + `        if (host === routed[i]) return "SOCKS5 127.0.0.1:${socksPort}";\n`
+        + `    return "${fallbackRule}";\n`
+        + "}\n";
 }
 
-export async function disable(_: IpcMainInvokeEvent) {
-    return { success: await clear() };
+function routedHosts(): string[] {
+    if (scope === "off") return [];
+    return scope === "login" ? [...GATEWAY_HOSTS, ...LOGIN_HOSTS] : [...GATEWAY_HOSTS];
+}
+
+// O PAC vai embutido na propria URL. A alternativa era servi-lo de um HTTP local, e ai o
+// Chromium precisa buscar o arquivo bem no meio da subida do app, com a rede ainda se
+// montando. Numa build de Electron mais antiga isso derrubava o processo principal em
+// silencio: o app nao abria, e nao havia excecao para pegar. Sem servidor nao ha busca.
+// Trocar o escopo troca o conteudo, e conteudo diferente ja e URL diferente, entao nao
+// precisa de numero de versao para o Chromium reler.
+function pacDataUrl(socksPort: number) {
+    const script = pacScript(socksPort, routedHosts());
+    return "data:application/x-ns-proxy-autoconfig;base64," + Buffer.from(script, "utf8").toString("base64");
+}
+
+async function installPac(redial: boolean) {
+    if (socks === undefined) return false;
+
+    try {
+        const socksPort = (socks.address() as AddressInfo | null)?.port;
+        if (socksPort === undefined) return false;
+
+        await session.defaultSession.setProxy({ mode: "pac_script", pacScript: pacDataUrl(socksPort) });
+
+        // Conferir em vez de supor. Se a regra nao pegou, e melhor sair direto de propria
+        // vontade do que ficar num meio termo em que o roteador existe e ninguem o usa,
+        // que foi como este plugin falhou em silencio antes.
+        // Confere o endereco inteiro, e nao so o numero da porta: a resposta de um PAC
+        // ignorado e a regra do sistema, e um "PROXY host:porta" dela pode conter os mesmos
+        // digitos por acaso. Ai a checagem diria que a rota pegou justamente quando nao pegou.
+        const route = await session.defaultSession.resolveProxy(`https://${GATEWAY_HOSTS[0]}`);
+        if (typeof route !== "string" || !route.includes(`127.0.0.1:${socksPort}`)) {
+            log("o Chromium ignorou o PAC, voltando para a regra do sistema");
+
+            // "system" e o que uma sessao intocada usa. Voltar para "direct" arrancaria o
+            // proxy do sistema de quem esta atras de PAC, VPN ou proxy corporativo.
+            await session.defaultSession.setProxy({ mode: "system" });
+
+            // Nada ficou roteado, e o escopo tem que dizer isso. Com ele mentindo "gateway",
+            // o retryWithProxy recarrega o cliente atras de uma rota que nao existe e queima
+            // as tentativas sem chance nenhuma de consertar a sessao.
+            scope = "off";
+            return false;
+        }
+
+        // Regra nova nao muda socket que ja nasceu, e o gateway costuma nascer antes daqui.
+        // Sem derrubar o que ja esta aberto o Discord fica com a rota velha a sessao inteira,
+        // que e exatamente o modo de falhar em silencio: o roteador de pe, ninguem passando
+        // por ele. So no boot, porque depois do login derrubar o gateway seria reconectar a
+        // sessao recem autenticada a toa.
+        if (redial) await session.defaultSession.closeAllConnections();
+    } catch {
+        log("nao consegui aplicar a regra de rota, a sessao continua como estava");
+        return false;
+    }
+
+    log(`rota aplicada: ${routedHosts().join(", ")} pelo roteador local, o resto em ${fallbackRule}`);
+    return true;
+}
+
+async function startRouter(next: Scope) {
+    scope = next;
+
+    if (socks === undefined) {
+        const server = createSocksServer(serveSocks);
+        server.on("error", () => { });
+
+        // A promessa resolve tambem no erro. Esperar por um listen que nunca vai acontecer
+        // deixaria o boot pendurado para sempre, e este codigo roda no caminho de abertura
+        // do Discord.
+        const started = await new Promise<boolean>(resolve => {
+            server.once("error", () => resolve(false));
+            server.listen(0, "127.0.0.1", () => resolve(true));
+        });
+
+        if (!started) {
+            log("nao consegui subir o roteador local, a sessao inteira continua direta");
+            return false;
+        }
+
+        socks = server;
+        log(`roteador local de pe na porta ${(server.address() as AddressInfo).port}`);
+    }
+
+    if (await installPac(true)) return true;
+
+    // Mesmo motivo de dentro do installPac, e vale tambem quando a excecao apareceu antes de
+    // a regra chegar a mudar: no boot nao havia rota nenhuma para sobreviver, entao o unico
+    // escopo verdadeiro depois de uma falha aqui e "off".
+    scope = "off";
+    return false;
+}
+
+async function stopRouter() {
+    scope = "off";
+
+    try {
+        // "system" e o que uma sessao intocada usa. Voltar para "direct" arrancaria o proxy
+        // do sistema de quem esta atras de PAC, VPN ou proxy corporativo.
+        await session.defaultSession.setProxy({ mode: "system" });
+        await session.defaultSession.closeAllConnections();
+    } catch {
+        // nada a fazer: a sessao ja esta fechando
+    }
+
+    socks?.close();
+    socks = undefined;
+    log("roteador desligado, tudo volta a sair direto");
+}
+
+// Sairam daqui tres protecoes da versao que aplicava proxy na sessao inteira: o prazo de
+// dois minutos que soltava o proxy sozinho, a marca de boot pendente gravada em disco para
+// nao repetir uma abertura travada, e o did-fail-load que desistia quando a pagina nao
+// carregava. As tres cobriam o mesmo acidente, saida quebrada segurando o Discord inteiro
+// sem tela e sem como pedir socorro, e esse acidente nao existe mais: so o gateway passa
+// pela saida, o resto do app nunca depende dela, e a conexao que depende cai para direta
+// sozinha dentro do roteador. Manter o prazo hoje seria dano puro, porque ele arrancaria o
+// gateway da saida no meio de uma sessao que estava funcionando.
+app.whenReady().then(async () => {
+    try {
+        if (!pluginEnabled()) return;
+
+        // A regra do sistema e lida antes de qualquer coisa, para o PAC saber para onde mandar
+        // tudo que nao e Discord.
+        try {
+            const resolved = await session.defaultSession.resolveProxy(`https://${DISCORD_HOST}`);
+            if (typeof resolved === "string" && resolved.trim() !== "") fallbackRule = resolved.trim();
+        } catch {
+            // fica em DIRECT
+        }
+
+        // Subir o roteador leva milissegundos, entao ele esta de pe antes do gateway nascer.
+        // Escolher a saida acontece depois, em paralelo com o app carregando.
+        await startRouter(routesLogin() ? "login" : "gateway");
+        chooseExit();
+    } catch {
+        // Falhar aqui e abrir o Discord sem bypass. Deixar a excecao subir era abrir o
+        // Discord sem processo principal, ou seja, nao abrir.
+        await stopRouter();
+    }
+}).catch(() => { });
+
+export async function sessionOpened(_: IpcMainInvokeEvent) {
+    // Com a sessao aberta o login ja passou, entao o escopo encolhe para o gateway e o resto
+    // do Discord volta a sair direto. O gateway continua roteado de proposito: se ele cair e
+    // reconectar (rede oscilando, notebook suspenso), o socket novo nasce pela mesma saida e
+    // a liberacao sobrevive, coisa que a versao anterior perdia.
+    if (scope === "login") await installPacWithScope("gateway");
+    return { exit, scope };
+}
+
+export async function sessionClosed(_: IpcMainInvokeEvent) {
+    if (routesLogin() && scope !== "off") await installPacWithScope("login");
+}
+
+// O escopo descreve o que esta instalado, nao o que foi pedido. Se a troca falhar no meio da
+// sessao a rota antiga continua valendo, e e ela que o diagnostico e o retryWithProxy
+// precisam enxergar. Quando o proprio installPac desliga tudo, o "off" dele e que vale.
+async function installPacWithScope(next: Scope) {
+    const installed = scope;
+    scope = next;
+
+    if (await installPac(false)) return true;
+
+    if (scope === next) scope = installed;
+    return false;
+}
+
+export async function shutdown(_: IpcMainInvokeEvent) {
+    await stopRouter();
+    settleExit(null);
+    return { success: true as const };
 }
 
 export function getActiveProxy(_: IpcMainInvokeEvent) {
-    return appliedProxy;
+    return exit;
 }
 
 export function getLog(_: IpcMainInvokeEvent) {
@@ -537,47 +921,62 @@ export function sessionWorked(_: IpcMainInvokeEvent) {
     retries = 0;
 }
 
-// Quando a sessao sobe sem passar pelo proxy, o servidor continua bloqueando video e nao ha
-// como consertar sem refazer o gateway. Recarregar com o proxy no ar resolve, mas so pode
-// acontecer um numero fixo de vezes: sem teto isso vira a tela de carregamento infinita.
+// O gateway pode nascer antes de existir saida escolhida: quando isso acontece ele sai
+// direto, o servidor continua bloqueando video, e nao ha como consertar sem refazer o
+// gateway. Recarregar com a saida ja pronta resolve, mas so pode acontecer um numero fixo de
+// vezes: sem teto isso vira a tela de carregamento infinita.
 export async function retryWithProxy(event: IpcMainInvokeEvent, excludedCountries: unknown) {
     if (retries >= MAX_RETRIES) {
         log(`o servidor continuou bloqueando apos ${retries} tentativas, desistindo`);
-        await clear();
         return { retried: false as const, reason: "tentativas esgotadas" };
     }
 
-    // Se o proxy que esta no ar ainda responde, a causa foi a corrida: o gateway nasceu antes
-    // dele. Recarregar faz o gateway renascer por tras do proxy, e isso conserta a sessao.
-    let proxy = appliedProxy;
-    if (proxy !== null && await probe(proxy) === null) {
-        log(`${proxy} parou de responder no meio da sessao`);
-        await clear();
-        proxy = null;
+    if (scope === "off") {
+        log("o roteador nao esta de pe, recarregar repetiria a mesma falha");
+        return { retried: false as const, reason: "roteador desligado" };
     }
 
-    // Sem proxy no ar, recarregar cairia no fallback direct:// e repetiria a mesma falha. Aqui
-    // nao ha corrida com o gateway para ganhar, entao vale a busca completa em vez dos prazos
-    // curtos do boot: gastar meio minuto e melhor que recarregar para nada.
-    if (proxy === null) {
-        const excluded = requestedCountries(excludedCountries);
-        const manual = manualProxy();
+    // A lista chega do renderer porque e a que a pessoa esta vendo nas settings agora; a copia
+    // lida no processo principal so muda depois que o renderer grava. Vazia quer dizer que nao
+    // veio nada util, e ai vale o que esta gravado.
+    const requested = requestedCountries(excludedCountries);
+    const excluded = requested.size > 0 ? requested : undefined;
 
-        proxy = (manual !== null && manual !== "" && await probe(manual) !== null ? manual : null)
-            ?? await detectTor(excluded)
-            ?? await sharedFreeProxy(excluded);
+    // Se a saida que esta no ar ainda responde, a causa foi a corrida: o gateway nasceu antes
+    // dela e o roteador o mandou direto. Recarregar faz o gateway renascer ja pela saida, e
+    // isso conserta a sessao. A rota nao precisa ser reinstalada, ela nunca saiu do lugar.
+    let through = exit;
+    if (through !== null && await measure(through, PROBE_TIMEOUT_MS) === null) {
+        log(`${through} parou de responder no meio da sessao`);
 
-        if (proxy === null || !await apply(proxy)) {
-            log("nenhum proxy respondeu, a sessao continua direta");
-            await clear();
-            return { retried: false as const, reason: "nenhum proxy respondeu" };
-        }
+        // A lista vai junto porque quem descarta ja comeca a procurar a substituta. Sem ela,
+        // a busca que o await abaixo aproveita seria a que ignora o pais que a pessoa acabou
+        // de excluir, e a tentativa seguinte nasceria no pais errado.
+        dropExit(through, excluded);
+
+        // Le de volta em vez de assumir null: se o trafego vivo ja tinha descartado esta saida
+        // e achado outra, ela serve, e comecar uma busca nova por cima jogaria fora a que esta
+        // funcionando neste instante.
+        through = exit;
+    }
+
+    // Sem saida no ar, recarregar cairia direto de novo e repetiria a mesma falha, gastando
+    // uma tentativa. Aqui nao ha corrida com o gateway para ganhar, entao vale esperar a
+    // busca inteira em vez dos prazos curtos do boot.
+    if (through === null) {
+        await chooseExit(excluded);
+        through = exit;
+    }
+
+    if (through === null) {
+        log("nenhuma saida respondeu, a sessao continua direta");
+        return { retried: false as const, reason: "nenhuma saida respondeu" };
     }
 
     if (event.sender.isDestroyed()) return { retried: false as const, reason: "janela indisponivel" };
 
     retries++;
-    log(`o servidor bloqueou esta sessao, recarregando atras de ${proxy} (tentativa ${retries} de ${MAX_RETRIES})`);
+    log(`o servidor bloqueou esta sessao, recarregando atras de ${through} (tentativa ${retries} de ${MAX_RETRIES})`);
 
     // event.sender e a janela que roda o plugin. Guardar a primeira janela criada nao servia:
     // a primeira do Discord e a tela de abertura, e recarregar ela nao recarrega o cliente.
@@ -589,9 +988,9 @@ export async function testProxy(_: IpcMainInvokeEvent, proxyRules: unknown) {
     if (typeof proxyRules !== "string" || parseProxy(proxyRules.trim()) === null)
         return { success: false as const, error: "Invalid proxy format. Use socks5://host:port." };
 
-    const result = await probe(proxyRules.trim());
+    const result = await measure(proxyRules.trim());
     if (result === null)
-        return { success: false as const, error: "The proxy could not carry a real request to Discord." };
+        return { success: false as const, error: "The proxy could not carry a real TLS request." };
 
-    return { success: true as const, ms: result.ms, country: await exitCountry(proxyRules.trim()) };
+    return { success: true as const, ms: result.ms, country: result.country, ip: result.ip };
 }


### PR DESCRIPTION
## O que motivou

O README diz que só o WebSocket de gateway passa pela proxy e que todo o resto sai na velocidade normal. Fui atrás disso porque a abertura do Discord estava demorando demais, e o `session.setProxy` do Electron vale para a sessão inteira: ele não sabe dizer "esta conexão sim, aquela não".

Então o boot inteiro saía pela proxy pública, tirando só o que estava no `proxyBypassRules`, e antes disso ainda esperava a escolha da proxy terminar, que pelo próprio README leva de 8 a 23 segundos.

## O que mudou

Um SOCKS5 local, e um PAC embutido numa `data:` URL mandando só `gateway.discord.gg` e `remote-auth-gateway.discord.gg` para ele. Todo outro host recebe a regra que o sistema já usava, lida do `resolveProxy` antes de tudo, então quem está atrás de proxy corporativo não perde o Discord.

Como subir isso leva milissegundos, a escolha da saída passou a acontecer em paralelo com o app carregando. O gateway que chega antes de existir saída espera no roteador local, até 12s, em vez de o app inteiro esperar por ele.

E como a regra fica instalada, uma reconexão do gateway não custa mais o Go Live até reiniciar o app.

O raciocínio de cada decisão está nos dois commits, inclusive o das proteções que foram removidas.

## O que eu verifiquei

Passando um Chromium de verdade pelo roteador:

- PAC entregue como `data:` URL é obedecido, e `SOCKS5 127.0.0.1:porta` funciona como retorno
- a separação por host é real: o host roteado atravessa o SOCKS e outro site carrega inteiro, com todos os subrecursos, sem encostar nele
- segurar a resposta do SOCKS por 6 segundos não derruba o pedido
- com a saída apontando para uma porta morta, a página ainda carrega, porque o roteador cai para direto sozinho

E no Discord, com dois clientes contornados ao mesmo tempo (Stable e PTB, contas diferentes, cada um com seu roteador e sua saída): transmissão e recepção de vídeo a **720p 30FPS**.

## Um achado que talvez te interesse mesmo que o PR não

Capturei o WebSocket de voz para entender onde exatamente a trava agia. Com o roteamento ativo, o servidor manda:

```
op12 VIDEO user=<par> video_ssrc=267 active:true 1280x720@30
```

e o cliente responde `op15 MEDIA_SINK_WANTS {"267":100}`.

Ou seja, dá para confirmar a liberação lendo o protocolo, sem depender de olhar a tela e concluir. Talvez ajude a firmar a seção "Go Live no Brasil: por que funciona", que hoje se apoia em observação indireta.

No mesmo teste, quando o par do outro lado não tem contorno, o SSRC de vídeo dele é anunciado normalmente mas nenhum pacote é retransmitido: medi de 0 a 23 pacotes por segundo com a câmera dele ligada, e zero NACKs. Isso me fez perder um bom tempo achando que o bug era do lado que recebe.

## Ressalvas

- Testado numa máquina só, no Windows 10, com Discord Stable e PTB. **Não rodei em Linux**, e o repositório tem instalador de Linux.
- Remove o prazo de 120s e a marca de boot de propósito, porque o cenário que elas cobriam (proxy quebrada segurando o app inteiro) deixou de existir quando o escopo virou um host. Se você discordar desse raciocínio, é a parte que eu tiraria primeiro.
- O `native.ts` quase dobrou de tamanho. Tenho consciência de que é bastante coisa chegando de fora, e entendo se preferir dividir ou pegar só um pedaço.

Se preferir implementar do seu jeito a partir da descrição, pode fechar tranquilo.
