### PR TITLE
Adiciona suporte a versão flatpak do Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Ou seja, o fluxo do GoLiveBypass — **boot inteiro atrás da proxy → proxy re
 
 ## Avisos importantes
 
-- **Só funciona no Discord para computador** com Equicord ou Vencord injetado. Vesktop e Equibop não são suportados pelos instaladores: eles trazem o mod embutido e não carregam de um checkout. Não funciona na versão de navegador/extensão.
+- **Só funciona no Discord para computador** com Equicord ou Vencord injetado, incluindo o Discord instalado por Flatpak. Vesktop e Equibop não são suportados pelos instaladores: eles trazem o mod embutido e não carregam de um checkout. Snap também não: ali o app fica dentro de um squashfs somente leitura. Não funciona na versão de navegador/extensão.
 - **Proxies gratuitas são fracas para anonimato**: o operador da proxy vê seus metadados de conexão, muitas estão mortas ou lentas, e o Discord pode pedir captcha para IPs de proxies públicas. Para anonimato real, **use Tor**.
 - Usar clientes modificados viola os Termos de Serviço do Discord. Use por sua conta e risco.
 - A proxy cobre apenas a **criação da sessão**. Depois que a sessão abre (`CONNECTION_OPEN`), o tráfego volta a ser direto com seu IP real.
@@ -322,11 +322,15 @@ Isto mudou em maio de 2026, na versão 1.0.136 do Discord, e a maior parte dos t
 | `discord_arch_electron` (AUR) | `/usr/share/discord/resources/` |
 | `discord-electron-openasar` (AUR) | `/usr/lib/discord/resources/` — **já tem OpenAsar** |
 | `discord-ptb` / `discord-canary` (AUR) | `/opt/discord-ptb/resources/`, `/opt/discord-canary/resources/` |
-| Flatpak, Snap | somente leitura, **não dá para injetar** |
+| Flatpak do sistema | `/var/lib/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/` |
+| Flatpak do usuário | `~/.local/share/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/` |
+| Snap | dentro de um squashfs, somente leitura de verdade: **não dá para injetar** |
 
-Duas consequências práticas:
+Três consequências práticas:
 
-**Quase sempre não precisa de `sudo`.** Se o seu Discord veio pelo caminho normal, o `app.asar` está na sua pasta pessoal. Os instaladores só pedem root quando o alvo realmente pertence ao root — os pacotes do AUR que ainda embutem o app.
+**Quase sempre não precisa de `sudo`.** Se o seu Discord veio pelo caminho normal, o `app.asar` está na sua pasta pessoal. Os instaladores só pedem root quando o alvo realmente pertence ao root — os pacotes do AUR que ainda embutem o app, e o Flatpak instalado para o sistema todo.
+
+**Flatpak funciona, e um `flatpak update` desfaz.** O deploy do Flatpak parece intocável mas é um diretório comum: a injeção só renomeia o `app.asar` e cria uma pasta ao lado, sem reescrever arquivo nenhum, então os objetos do repositório ostree ficam intactos. O que muda é que cada atualização refaz o deploy inteiro e leva a injeção junto — rode o instalador de novo depois. Os instaladores também precisam liberar a pasta do bypass para o sandbox (`flatpak override --filesystem=`), senão o Discord abre reclamando de módulo não encontrado.
 
 **A atualização do Discord desfaz a injeção.** Ele baixa a versão nova numa pasta `app-<versão>` inteiramente nova, e o que você injetou fica na pasta velha. Não dá para impedir isso de fora: rode o instalador de novo depois de atualizar. O instalador avisa quando esse é o seu caso.
 
@@ -442,7 +446,7 @@ Se der erro de permissão no Windows, abra o PowerShell **como administrador** e
 
 O plugin **só funciona no app de computador** (ele usa recursos do Electron que o navegador não tem):
 
-- **Discord normal**: baixe em [discord.com/download](https://discord.com/download) (stable, PTB ou Canary servem); ou
+- **Discord normal**: baixe em [discord.com/download](https://discord.com/download) (stable, PTB ou Canary servem). O Flatpak (`com.discordapp.Discord`) também serve, do sistema ou do usuário; ou
 - **Vesktop/Equibop**: apps alternativos que já trazem o mod embutido. Os instaladores daqui não mexem neles.
 - **Não funciona** no Discord aberto no navegador nem no celular.
 
@@ -546,7 +550,7 @@ Se o Discord reconectar o gateway sozinho no meio da sessão (queda de rede, sus
 
 ## Solução de problemas
 
-- **Discord carregando infinitamente**: normalmente ele se resolve sozinho, porque uma inicialização que não terminou deixa uma marca e a seguinte se recusa a aplicar proxy. Se persistir, com o Discord fechado abra `%APPDATA%/Equicord/settings/settings.json` (ou `.../Vencord/...`) e coloque `"GoLiveBypass": { "enabled": false }`. Em `native-settings.json` as chaves deste plugin são `verifiedProxy` (a proxy guardada) e `bootPending` (a marca); apagar as duas devolve tudo ao estado inicial. Se você usou uma versão anterior, apague também `lastKnownProxy`, que não é mais lida.
+- **Discord carregando infinitamente**: normalmente ele se resolve sozinho, porque uma inicialização que não terminou deixa uma marca e a seguinte se recusa a aplicar proxy. Se persistir, com o Discord fechado abra `%APPDATA%/Equicord/settings/settings.json` (ou `.../Vencord/...`; no Linux `~/.config/Equicord/settings/settings.json`, e com Discord por Flatpak `~/.var/app/com.discordapp.Discord/config/Equicord/settings/settings.json`) e coloque `"GoLiveBypass": { "enabled": false }`. Em `native-settings.json` as chaves deste plugin são `verifiedProxy` (a proxy guardada) e `bootPending` (a marca); apagar as duas devolve tudo ao estado inicial. Se você usou uma versão anterior, apague também `lastKnownProxy`, que não é mais lida.
 - **"GoLiveBypass is reconnecting behind the proxy"**: a proxy ficou pronta depois de o gateway já ter conectado, então a sessão nasceu desprotegida e o servidor manteve o bloqueio. O plugin procura uma proxy que responda e recarrega o cliente sozinho para a sessão renascer atrás dela. São no máximo duas tentativas: sem esse teto, um bloqueio que a proxy não resolve viraria recarregamento sem fim.
 - **Meu proxy pede usuário e senha**: coloque no próprio endereço, `socks5://usuario:senha@host:porta`. Funciona para SOCKS5 e para proxy HTTP. Se a senha tiver `@` ou `:`, codifique esses caracteres (`@` vira `%40`, `:` vira `%3A`) — sem isso não dá para saber onde a senha termina. A senha nunca aparece no registro.
 - **"No proxy could carry a real request to Discord"**: nenhuma candidata passou no teste TLS real naquele momento. Tente de novo, ou use Tor / uma proxy sua no campo Proxy.
@@ -565,6 +569,9 @@ Tudo o que o bypass faz vai para um arquivo, no plugin e no standalone, **no mes
 |---|---|
 | Windows | `%LOCALAPPDATA%\GoLiveBypass\golivebypass.log` |
 | Linux | `~/.local/share/GoLiveBypass/golivebypass.log` |
+| Linux, plugin com Discord por Flatpak | `~/.var/app/com.discordapp.Discord/data/GoLiveBypass/golivebypass.log` |
+
+A linha do Flatpak não é uma exceção do plugin: ele grava em `$XDG_DATA_HOME/GoLiveBypass`, e dentro do sandbox essa variável aponta para outro lugar. Pelo mesmo motivo as configurações do mod ficam em `~/.var/app/com.discordapp.Discord/config/Equicord/settings/settings.json` (ou `.../Vencord/...`), e não em `~/.config`. O standalone não muda de lugar: o `.js` mora fora do sandbox, e o registro fica ao lado dele.
 
 Ele é cortado sozinho quando passa de 256 KB, então não cresce sem fim.
 
@@ -652,7 +659,7 @@ exigia entender o que é um checkout, um gerenciador de pacotes e uma etapa de c
 
 It was written after Brazil's data protection authority (ANPD) [ordered Discord to suspend live streaming (Go Live) in Brazil](https://www.gov.br/anpd/pt-br/assuntos/noticias/em-medida-preventiva-anpd-determina-que-discord-suspenda-transmissoes-ao-vivo-no-brasil) in August 2026, shortly after the country blocked X (Twitter). It works while the gateway WebSocket stays alive. If it reconnects over your real IP, Ctrl+R will not help: the proxy is only applied before the gateway is created, so you have to quit Discord from the tray and open it again. Bypassing the restriction may violate Discord's ToS.
 
-- Desktop Discord with Equicord or Vencord injected. Vesktop and Equibop are not supported by the installers, since they bundle the mod instead of loading it from a checkout. Not available on the browser extension.
+- Desktop Discord with Equicord or Vencord injected, Flatpak included. Vesktop and Equibop are not supported by the installers, since they bundle the mod instead of loading it from a checkout; neither is Snap, whose app lives in a read-only squashfs. Not available on the browser extension.
 - Dependencies: Git, Node.js 22+, pnpm 11 (via `corepack enable`), and a desktop Discord client. Tor is optional, not required: by default the plugin picks and validates a free proxy on its own.
 - **Your calls stay on the region you pick.** Creating the session abroad makes Discord rank foreign voice servers, so the plugin overrides the three `RTCRegionStore` getters that feed `preferred_region` / `preferred_regions` in the gateway `VOICE_STATE_UPDATE`. The override is evaluated at read time, so Discord's latency test cannot undo it, and it writes nothing into Discord's persisted state, so the region is not left pinned after you remove the plugin. Restored on `stop()`.
 - Proxy order: your manual proxy, then a local Tor (`127.0.0.1:9150` for Tor Browser, `9050` for the daemon), then a validated free proxy.

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -5,6 +5,8 @@
 # Encontra sozinho o Equicord ou o Vencord que voce tem, instala o plugin, compila e injeta.
 # Se voce nao tiver nenhum dos dois, pergunta qual quer e instala junto.
 #
+# Funciona tambem com o Discord instalado por flatpak, do sistema ou do usuario.
+#
 # Uso:
 #   ./golivebypass-installer.sh
 #   ./golivebypass-installer.sh --source ~/Equicord
@@ -22,6 +24,7 @@ PLUGIN_FILES=("goLiveBypass/index.tsx" "goLiveBypass/native.ts")
 PLUGIN_DIR_NAME="goLiveBypass"
 EQUICORD_GIT="https://github.com/Equicord/Equicord"
 VENCORD_GIT="https://github.com/Vendicated/Vencord"
+FLATPAK_IDS=("com.discordapp.Discord" "com.discordapp.DiscordPTB" "com.discordapp.DiscordCanary")
 
 MODE="menu"
 MOD=""
@@ -63,6 +66,60 @@ confirm() {
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
+# O id do flatpak a que um caminho pertence, ou nada se o caminho nao for de flatpak. Serve
+# para os dois lugares onde o Discord de flatpak aparece: o deploy em .../flatpak/app/<id>/ e
+# o HOME do sandbox em ~/.var/app/<id>/.
+flatpak_app_id() {
+    local parte
+    while IFS= read -r parte; do
+        case "$parte" in com.discordapp.*) printf '%s\n' "$parte"; return 0 ;; esac
+    done < <(printf '%s\n' "${1:-}" | tr '/' '\n')
+    return 1
+}
+
+# Instalacao do usuario nao precisa de raiz para nada; a do sistema precisa para tudo. O
+# `flatpak override` obedece essa mesma divisao, e passar --user na do sistema falha.
+flatpak_is_user_install() {
+    have flatpak && flatpak info --user "$1" >/dev/null 2>&1
+}
+
+# A liberacao ja existente aparece no --show-permissions, que nao precisa de raiz. Conferir
+# antes evita pedir a senha do sudo toda vez que o instalador roda de novo.
+flatpak_has_access() {
+    local entrada
+    # Entrada por entrada, e comparando o texto inteiro: depois de um --nofilesystem a pasta
+    # continua aparecendo na lista, so que como !pasta. Procurar o pedaco solto acharia essa
+    # negacao e concluiria que o acesso existe, justamente quando ele nao existe mais.
+    while IFS= read -r entrada; do
+        case "$entrada" in
+            "$2"|"$2:rw"|"$2:ro"|"$2:create") return 0 ;;
+        esac
+    done < <(flatpak info --show-permissions "$1" 2>/dev/null | sed -n 's/^filesystems=//p' | tr ';' '\n')
+    return 1
+}
+
+# O flatpak so enxerga o proprio sandbox. Sem liberar a pasta de build do mod, o Discord abre
+# reclamando de modulo nao encontrado: o index.js injetado faz require de um caminho que de
+# dentro do sandbox nao existe. O instalador do mod ja faz isso sozinho, mas nao no caminho em
+# que a injecao ja estava pronta e nos so reiniciamos o Discord.
+grant_flatpak_access() {
+    local id="$1" dir="$2"
+    have flatpak || return 0
+    flatpak_has_access "$id" "$dir" && return 0
+
+    if flatpak_is_user_install "$id"; then
+        flatpak override --user "$id" --filesystem="$dir" >/dev/null 2>&1 && return 0
+    else
+        step "Liberando $dir para o $id (pode pedir sua senha do sudo)"
+        sudo flatpak override "$id" --filesystem="$dir" >/dev/null 2>&1 && return 0
+    fi
+
+    warn "Nao consegui liberar $dir para o $id. Se o Discord abrir com erro de modulo, rode:"
+    printf '  %s  flatpak override %s--filesystem=%s %s%s\n' \
+        "$C_DIM" "$(flatpak_is_user_install "$id" && printf -- '--user ')" "$dir" "$id" "$C_OFF" >&2
+    return 1
+}
+
 # O endereco da proxy pode carregar usuario e senha, e ele e mostrado na tela. A senha some.
 hide_proxy_secret() {
     printf '%s\n' "$1" | sed -E 's#^([a-z0-9]+)://([^:@/]+)(:[^@/]*)?@#\1://\2:***@#'
@@ -76,7 +133,7 @@ hide_proxy_secret() {
 have_pnpm() { have pnpm && pnpm --version >/dev/null 2>&1; }
 
 usage() {
-    sed -n '3,16p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '3,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
     exit 0
 }
 
@@ -110,7 +167,7 @@ is_checkout() {
 # primeira execucao para dentro do HOME. Quem so olha /usr/share e /opt nao acha Discord nenhum
 # numa instalacao atual.
 discord_resources() {
-    local raiz sub base
+    local raiz sub base id
 
     base="${XDG_CONFIG_HOME:-$HOME/.config}"
     for sub in \
@@ -140,7 +197,69 @@ discord_resources() {
             fi
         done
     done
+
+    # Flatpak. O app fica no deploy do ostree, que e do root, mas e um diretorio comum num
+    # sistema de arquivos comum: a injecao troca o nome do app.asar e cria uma pasta ao lado,
+    # sem reescrever nenhum arquivo, entao os objetos do repositorio ficam intactos. E o que o
+    # instalador do Equicord e o do Vencord ja fazem ha tempos. O preco e que um
+    # `flatpak update` refaz o deploy e leva a injecao junto.
+    for raiz in /var/lib/flatpak/app "${XDG_DATA_HOME:-$HOME/.local/share}/flatpak/app"; do
+        [ -d "$raiz" ] || continue
+        for id in "${FLATPAK_IDS[@]}"; do
+            for sub in "$raiz/$id"/current/active/files/*/resources; do
+                if [ -e "$sub/app.asar" ] || [ -e "$sub/_app.asar" ]; then
+                    printf '%s\n' "$sub"
+                fi
+            done
+        done
+    done
+
+    # E o bootstrap de que fala o comentario aqui em cima, so que dentro do flatpak: o HOME do
+    # Discord vira ~/.var/app/<id>, e o app baixado cai la. Este e do proprio usuario, sem sudo.
+    for id in "${FLATPAK_IDS[@]}"; do
+        for sub in "$HOME/.var/app/$id"/config/discord*/app-*/resources; do
+            if [ -e "$sub/app.asar" ] || [ -e "$sub/_app.asar" ]; then
+                printf '%s\n' "$sub"
+            fi
+        done
+    done
+
     return 0
+}
+
+# O que passar em --location para o instalador do mod. Ele quer a pasta de cima, e no flatpak
+# quer o diretorio do app inteiro: e de la que ele descobre que aquilo e um flatpak e libera o
+# sandbox. Apontar direto para .../current/active/files/discord faz a liberacao nao acontecer,
+# e o Discord abre com erro de modulo.
+install_location() {
+    local resources="$1"
+    case "$resources" in
+        */current/active/*) printf '%s\n' "${resources%%/current/active/*}" ;;
+        */app-*/resources)  dirname "$(dirname "$resources")" ;;
+        */resources)        dirname "$resources" ;;
+        *)                  printf '%s\n' "$resources" ;;
+    esac
+}
+
+# O resources cujo app.asar aponta para este checkout, seja ele qual for. Base das tres
+# perguntas que o resto do script faz: se a injecao pegou, se ela caiu num flatpak, e em qual.
+injected_resources() {
+    local root="${1:-}" resources path
+    [ -n "$root" ] || return 1
+    while IFS= read -r resources; do
+        path="$(injected_path "$resources" || true)"
+        [ -n "$path" ] || continue
+        case "$path" in "$root"/*) printf '%s\n' "$resources"; return 0 ;; esac
+    done < <(discord_resources)
+    return 1
+}
+
+# O id do flatpak cuja injecao aponta para este checkout, se for o caso. Decide onde ficam as
+# configuracoes do mod e como reabrir o Discord.
+injected_flatpak_id() {
+    local resources
+    resources="$(injected_resources "${1:-}")" || return 1
+    flatpak_app_id "$resources"
 }
 
 # O instalador do Equicord e o do Vencord trocam o app.asar por um stub cujo index.js so faz
@@ -228,13 +347,7 @@ find_checkout() {
 }
 
 injected_from_checkout() {
-    local root="$1" resources path
-    while IFS= read -r resources; do
-        path="$(injected_path "$resources" || true)"
-        [ -n "$path" ] || continue
-        case "$path" in "$root"/*) return 0 ;; esac
-    done < <(discord_resources)
-    return 1
+    injected_resources "$1" >/dev/null
 }
 
 # ----------------------------------------------------------------------------- instalacao
@@ -435,16 +548,38 @@ repo_file() {
     fi
 }
 
+# O processo do flatpak tem o mesmo nome de sempre e o pgrep costuma achar, mas ele roda em
+# outro namespace de PID e um pkill pode nao alcancar. O `flatpak ps` responde pelo que o
+# pgrep nao ve, e o `flatpak kill` fecha o que o pkill nao fecha.
+discord_running() {
+    pgrep -x -i 'Discord|DiscordCanary|DiscordPTB' >/dev/null 2>&1 && return 0
+
+    # Um `flatpak ps` so, e nao um por id: isto roda em laco de dois em dois segundos enquanto
+    # o modo temporario espera o Discord fechar.
+    if have flatpak; then
+        local rodando
+        rodando="$(flatpak ps --columns=application 2>/dev/null || true)"
+        case "$rodando" in *com.discordapp.*) return 0 ;; esac
+    fi
+    return 1
+}
+
 stop_discord() {
-    pgrep -x -i 'Discord|DiscordCanary|DiscordPTB' >/dev/null 2>&1 || return 0
+    discord_running || return 0
 
     step "Fechando o Discord"
     pkill -x -i 'Discord|DiscordCanary|DiscordPTB' >/dev/null 2>&1 || true
+    if have flatpak; then
+        local id
+        for id in "${FLATPAK_IDS[@]}"; do
+            flatpak kill "$id" >/dev/null 2>&1 || true
+        done
+    fi
 
     local i
     for i in $(seq 1 30); do
         sleep 0.3
-        pgrep -x -i 'Discord|DiscordCanary|DiscordPTB' >/dev/null 2>&1 || return 0
+        discord_running || return 0
     done
 
     fail "O Discord nao fechou. Feche na mao e rode de novo."
@@ -485,15 +620,93 @@ build_mod() {
     (cd "$root" && pnpm build) || fail "pnpm build falhou"
 }
 
+# --location poupa a pergunta do instalador do mod quando so ha um Discord, e de quebra deixa
+# a escolha do sudo certa: da para saber de antemao onde a injecao vai cair. Com mais de um,
+# quem escolhe e o instalador do mod, que lista todos.
+run_inject() {
+    local root="$1" loc="${2:-}"
+
+    # Nem todo pnpm come o -- antes de repassar o resto, e o instalador do mod que recebe um --
+    # solto para de ler opcoes ali e ignora o --location. Nao da para impedir de fora; da para
+    # cair no caminho de sempre, que e o instalador do mod perguntando qual Discord usar.
+    if [ -n "$loc" ] && (cd "$root" && pnpm run inject -- --location "$loc"); then
+        return 0
+    fi
+
+    (cd "$root" && pnpm inject)
+}
+
+# O sudo limpa o ambiente, e sem PATH nem o pnpm nem o node sobrevivem. E o instalador do mod
+# que o pnpm baixa vai parar em dist/ como root: sem devolver o dono, o proximo build sem sudo
+# quebra com permissao negada numa pasta que era do usuario.
+run_inject_root() {
+    local root="$1" loc="${2:-}" rc=0
+    local -a cmd
+    if [ -n "$loc" ]; then
+        cmd=(pnpm run inject -- --location "$loc")
+    else
+        cmd=(pnpm inject)
+    fi
+
+    # Sem HOME de proposito: o instalador do mod ja descobre o HOME de verdade pelo SUDO_USER,
+    # e mandar o do usuario so faria o pnpm encher ~/.cache de arquivo do root.
+    sudo env PATH="$PATH" bash -c 'cd "$1" || exit 1; shift; exec "$@"' _ "$root" "${cmd[@]}" || rc=$?
+
+    # Mesmo motivo do run_inject: se o --location nao chegou, tentar sem ele.
+    if [ "$rc" -ne 0 ] && [ -n "$loc" ]; then
+        rc=0
+        sudo env PATH="$PATH" bash -c 'cd "$1" || exit 1; shift; exec "$@"' _ "$root" pnpm inject || rc=$?
+    fi
+
+    sudo chown -R "$(id -u):$(id -g)" "$root/dist" 2>/dev/null || true
+    return "$rc"
+}
+
 inject_mod() {
     local root="$1"
+    local -a alvos=()
+    local alvo="" loc="" id=""
+
+    mapfile -t alvos < <(discord_resources)
+    if [ "${#alvos[@]}" -eq 1 ]; then
+        alvo="${alvos[0]}"
+        loc="$(install_location "$alvo")"
+    fi
+
+    if [ -n "$alvo" ] && id="$(flatpak_app_id "$alvo")"; then
+        step "Discord instalado por flatpak ($id)"
+    fi
+
     stop_discord
-    step "Injetando no Discord (pode pedir sua senha do sudo)"
-    (cd "$root" && pnpm inject) || true
+
+    # Fora do HOME a injecao precisa de raiz, e o instalador do mod nao pede sozinho: ele so
+    # falha com permissao negada. Perguntar antes vale mais que falhar e mandar tentar de novo.
+    if [ -n "$alvo" ] && [ ! -w "$alvo" ]; then
+        printf '  %sO Discord esta em %s, fora do seu HOME.%s\n' "$C_DIM" "$alvo" "$C_OFF" >&2
+        confirm "A injecao ai precisa de sudo. Posso rodar com sudo?" \
+            || fail "Sem sudo nao da para injetar nesse Discord. Rode: cd $root && sudo pnpm inject"
+        step "Injetando no Discord"
+        run_inject_root "$root" "$loc" || true
+    else
+        step "Injetando no Discord (pode pedir sua senha do sudo)"
+        run_inject "$root" "$loc" || true
+
+        # O instalador do mod tambem cai aqui quando o Discord escolhido na lista dele estava
+        # fora do HOME, e ai o sudo so aparece como opcao depois.
+        if ! injected_from_checkout "$root" && confirm "Nao pegou. Tentar de novo com sudo?"; then
+            run_inject_root "$root" "$loc" || true
+        fi
+    fi
 
     # O pnpm inject sai com 0 mesmo quando o instalador do mod falha, entao o codigo de saida
     # nao serve de prova. Conferir se a injecao realmente passou a apontar para este checkout.
-    injected_from_checkout "$root" || fail "A injecao nao pegou. Se o Discord estiver em /usr/share ou /opt, rode: cd $root && sudo pnpm inject"
+    injected_from_checkout "$root" || fail "A injecao nao pegou. Se o Discord estiver em /usr/share, /opt ou num flatpak, rode: cd $root && sudo pnpm inject"
+
+    # De novo por conta propria, e nao so confiando no instalador do mod: ele so libera o
+    # sandbox quando descobre sozinho que aquilo e um flatpak, e o comando e idempotente.
+    if id="$(injected_flatpak_id "$root")"; then
+        grant_flatpak_access "$id" "$root/dist"
+    fi
 }
 
 checkout_mod() {
@@ -521,8 +734,16 @@ mod_settings_file() {
     # Mesma regra do proprio mod (src/main/utils/constants.ts):
     #   DATA_DIR = <MOD>_USER_DATA_DIR ?? ~/.config/<Mod>
     local root="$1"
-    local mod
+    local mod id
     mod="$(checkout_mod "$root")"
+
+    # Dentro do flatpak o HOME e outro: o ~/.config do mod cai em ~/.var/app/<id>/config. Um
+    # settings.json escrito no ~/.config de fora nao seria lido por ninguem, e o plugin abriria
+    # desligado depois de o instalador dizer que ativou.
+    if id="$(injected_flatpak_id "$root")"; then
+        printf '%s\n' "$HOME/.var/app/$id/config/$mod/settings/settings.json"
+        return 0
+    fi
 
     local override="${mod^^}_USER_DATA_DIR"
     if [ -n "${!override:-}" ]; then
@@ -574,13 +795,15 @@ set_plugin_settings() {
 
 show_status() {
     local root="${1:-}"
-    local count mod plugin
+    local count mod plugin extra=""
     count="$(discord_resources | wc -l)"
     mod="$(installed_mod || true)"
 
+    if discord_resources | grep -q '/com\.discordapp\.'; then extra=", flatpak"; fi
+
     printf '  %sDetectado:%s\n' "$C_BOLD" "$C_OFF"
     if [ "$count" -gt 0 ]; then
-        printf '  %s  Discord   instalado (%s)%s\n' "$C_DIM" "$count" "$C_OFF"
+        printf '  %s  Discord   instalado (%s%s)%s\n' "$C_DIM" "$count" "$extra" "$C_OFF"
     else
         printf '  %s  Discord   nao encontrado%s\n' "$C_YELLOW" "$C_OFF"
     fi
@@ -663,7 +886,15 @@ select_persistence() {
 }
 
 start_discord() {
-    local exe
+    local root="${1:-}" exe id
+
+    # Quem tem o flatpak e um Discord nativo pela metade acabaria com o nativo aberto, sem o
+    # mod, e concluiria que a instalacao falhou. Abrir o mesmo que foi injetado resolve.
+    if id="$(injected_flatpak_id "$root")" && have flatpak; then
+        nohup flatpak run "$id" >/dev/null 2>&1 &
+        return 0
+    fi
+
     for exe in discord Discord discord-canary; do
         if have "$exe"; then
             nohup "$exe" >/dev/null 2>&1 &
@@ -679,7 +910,7 @@ wait_discord_exit() {
     warn "Deixe este terminal aberto. Quando voce fechar o Discord, eu desfaco a injecao."
 
     sleep 5
-    while pgrep -x -i 'Discord|DiscordCanary|DiscordPTB' >/dev/null 2>&1; do sleep 2; done
+    while discord_running; do sleep 2; done
 
     printf '\n'
     step "Discord fechado, desfazendo a injecao"
@@ -702,18 +933,25 @@ do_install() {
     copy_plugin "$root"
     build_mod "$root"
 
+    local flatpak_id=""
     if injected_from_checkout "$root"; then
         step "O Discord ja carrega deste checkout, so reiniciando"
         stop_discord
+        # Por aqui o instalador do mod nao roda, e a liberacao do sandbox nao acontece
+        # sozinha. Se ela tiver caido num `flatpak update`, o Discord abriria com erro.
+        if flatpak_id="$(injected_flatpak_id "$root")"; then
+            grant_flatpak_access "$flatpak_id" "$root/dist"
+        fi
     else
         inject_mod "$root"
+        flatpak_id="$(injected_flatpak_id "$root" || true)"
     fi
 
     # Com o Discord fechado: aberto, ele regrava o settings.json a partir da memoria e
     # apaga o que escrevemos aqui.
     set_plugin_settings "$root" "$proxy"
 
-    start_discord
+    start_discord "$root"
 
     printf '\n'
     ok "Pronto. O plugin ja vem ativado, nao precisa mexer em nada."
@@ -725,6 +963,18 @@ do_install() {
         printf '  %sProxy: gratuita, escolhida e testada sozinha a cada abertura%s\n' "$C_DIM" "$C_OFF"
     fi
     printf '  %sEntre numa call e use Go Live ou a camera.%s\n' "$C_DIM" "$C_OFF"
+
+    # O deploy do flatpak e refeito do zero a cada atualizacao, e a injecao mora dentro dele.
+    # Nao da para impedir isso de fora, entao o que resta e avisar antes de acontecer.
+    if [ -n "$flatpak_id" ]; then
+        case "$(injected_resources "$root")" in
+            */flatpak/app/*)
+                printf '\n'
+                warn "Este Discord e flatpak: um 'flatpak update' desfaz a injecao."
+                printf '  %sQuando isso acontecer, rode este instalador de novo.%s\n' "$C_DIM" "$C_OFF"
+                ;;
+        esac
+    fi
 
     [ "$permanent" -eq 1 ] && wait_discord_exit "$root"
     return 0
@@ -744,7 +994,7 @@ do_uninstall() {
 
     build_mod "$root"
     stop_discord
-    start_discord
+    start_discord "$root"
 
     printf '\n'
     ok "Plugin removido. Seu Equicord/Vencord continua funcionando."

--- a/standalone/golivebypass-standalone.sh
+++ b/standalone/golivebypass-standalone.sh
@@ -5,6 +5,8 @@
 # Instala direto no Discord, sem Equicord e sem Vencord. Nao precisa de Node, nem de pnpm,
 # nem de git: o bypass e um arquivo .js que o proprio Discord carrega.
 #
+# Funciona tambem com o Discord instalado por flatpak, do sistema ou do usuario.
+#
 # Uso:
 #   ./golivebypass-standalone.sh
 #   ./golivebypass-standalone.sh --proxy socks5://127.0.0.1:9050
@@ -16,6 +18,7 @@ set -euo pipefail
 PATCHER_NAME="golivebypass.js"
 INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/GoLiveBypass"
 STUB_PACKAGE='{"name":"discord","main":"index.js"}'
+FLATPAK_IDS=("com.discordapp.Discord" "com.discordapp.DiscordPTB" "com.discordapp.DiscordCanary")
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 MODE="install"
@@ -81,7 +84,7 @@ confirm() {
 # O app de verdade, com o app.asar, e baixado na primeira execucao para dentro do HOME. Quem
 # so olha /usr/share e /opt nao acha Discord nenhum numa instalacao atual.
 discord_dirs() {
-    local raiz sub base
+    local raiz sub base id
 
     base="${XDG_CONFIG_HOME:-$HOME/.config}"
     for sub in \
@@ -113,6 +116,92 @@ discord_dirs() {
         done
     done
 
+    # Flatpak. O deploy do ostree e do root, mas e um diretorio comum: a injecao troca o nome
+    # do app.asar e cria uma pasta ao lado, sem reescrever arquivo nenhum, entao os objetos do
+    # repositorio ficam intactos. O que muda em relacao ao resto e que um `flatpak update`
+    # refaz o deploy inteiro e leva a injecao junto.
+    for raiz in /var/lib/flatpak/app "${XDG_DATA_HOME:-$HOME/.local/share}/flatpak/app"; do
+        [ -d "$raiz" ] || continue
+        for id in "${FLATPAK_IDS[@]}"; do
+            for sub in "$raiz/$id"/current/active/files/*/resources; do
+                if [ -e "$sub/app.asar" ] || [ -e "$sub/_app.asar" ]; then
+                    printf '%s\n' "$sub"
+                fi
+            done
+        done
+    done
+
+    # O mesmo bootstrap de que fala o comentario la em cima, so que dentro do flatpak: o HOME
+    # do Discord vira ~/.var/app/<id>, e o app baixado cai la. Este e do proprio usuario.
+    for id in "${FLATPAK_IDS[@]}"; do
+        for sub in "$HOME/.var/app/$id"/config/discord*/app-*/resources; do
+            if [ -e "$sub/app.asar" ] || [ -e "$sub/_app.asar" ]; then
+                printf '%s\n' "$sub"
+            fi
+        done
+    done
+
+    return 0
+}
+
+# O id do flatpak a que um caminho pertence, ou nada se o caminho nao for de flatpak.
+flatpak_app_id() {
+    local parte
+    while IFS= read -r parte; do
+        case "$parte" in com.discordapp.*) printf '%s\n' "$parte"; return 0 ;; esac
+    done < <(printf '%s\n' "${1:-}" | tr '/' '\n')
+    return 1
+}
+
+flatpak_is_user_install() {
+    have flatpak && flatpak info --user "$1" >/dev/null 2>&1
+}
+
+# A liberacao ja existente aparece no --show-permissions, que nao precisa de raiz. Conferir
+# antes evita pedir a senha do sudo toda vez que o instalador roda de novo.
+flatpak_has_access() {
+    local entrada
+    # Entrada por entrada, e comparando o texto inteiro: depois de um --nofilesystem a pasta
+    # continua aparecendo na lista, so que como !pasta. Procurar o pedaco solto acharia essa
+    # negacao e concluiria que o acesso existe, justamente quando ele nao existe mais.
+    while IFS= read -r entrada; do
+        case "$entrada" in
+            "$2"|"$2:rw"|"$2:ro"|"$2:create") return 0 ;;
+        esac
+    done < <(flatpak info --show-permissions "$1" 2>/dev/null | sed -n 's/^filesystems=//p' | tr ';' '\n')
+    return 1
+}
+
+# O flatpak so enxerga o proprio sandbox, e o bypass mora fora dele. Sem esta liberacao o
+# index.js injetado faz require de um caminho que de dentro do sandbox nao existe, e o Discord
+# abre em tela branca. Precisa ser leitura e escrita: o registro tambem e gravado aqui.
+grant_flatpak_access() {
+    local id="$1" dir="$2"
+    have flatpak || return 0
+    flatpak_has_access "$id" "$dir" && return 0
+
+    if flatpak_is_user_install "$id"; then
+        flatpak override --user "$id" --filesystem="$dir" >/dev/null 2>&1 && return 0
+    else
+        step "Liberando $dir para o $id"
+        sudo flatpak override "$id" --filesystem="$dir" >/dev/null 2>&1 && return 0
+    fi
+
+    warn "Nao consegui liberar $dir para o $id. Se o Discord abrir em branco, rode:"
+    printf '      %sflatpak override %s--filesystem=%s %s%s\n' \
+        "$C_DIM" "$(flatpak_is_user_install "$id" && printf -- '--user ')" "$dir" "$id" "$C_OFF" >&2
+    return 1
+}
+
+revoke_flatpak_access() {
+    local id="$1" dir="$2"
+    have flatpak || return 0
+
+    if flatpak_is_user_install "$id"; then
+        flatpak override --user "$id" --nofilesystem="$dir" >/dev/null 2>&1 || true
+    else
+        sudo flatpak override "$id" --nofilesystem="$dir" >/dev/null 2>&1 || true
+    fi
     return 0
 }
 
@@ -126,18 +215,14 @@ aviso_openasar() {
     return 0
 }
 
-# Flatpak e snap montam o app somente leitura, e a injecao nao tem como acontecer la dentro.
-# Detectar isso vale mais que falhar no meio com "permissao negada".
+# O snap monta o app dentro de um squashfs, que e somente leitura de verdade: nem o root
+# escreve la. Detectar isso vale mais que falhar no meio com "permissao negada". O flatpak nao
+# entra nesta lista: o deploy dele e um diretorio comum, e a injecao funciona.
 aviso_empacotado() {
-    if have flatpak && flatpak list --app 2>/dev/null | grep -qi "com.discordapp.Discord"; then
-        warn "Voce tem o Discord por Flatpak, e ali o sistema de arquivos e somente leitura."
-        printf '      %sA injecao nao acontece dentro de um Flatpak. Para usar o standalone,%s\n' "$C_DIM" "$C_OFF" >&2
-        printf '      %sinstale o Discord pelo site oficial ou pelo gerenciador da sua distro.%s\n' "$C_DIM" "$C_OFF" >&2
-    fi
-
     if have snap && snap list 2>/dev/null | grep -qi "^discord"; then
-        warn "Voce tem o Discord por snap, que tambem e somente leitura."
-        printf '      %sMesma coisa: instale pelo site oficial ou pela sua distro.%s\n' "$C_DIM" "$C_OFF" >&2
+        warn "Voce tem o Discord por snap, e ali o sistema de arquivos e somente leitura."
+        printf '      %sA injecao nao acontece dentro de um snap. Para usar o standalone,%s\n' "$C_DIM" "$C_OFF" >&2
+        printf '      %sinstale o Discord por flatpak, pelo site oficial ou pela sua distro.%s\n' "$C_DIM" "$C_OFF" >&2
     fi
 
     return 0
@@ -168,16 +253,38 @@ as_root() {
     fi
 }
 
+# O Discord de flatpak roda em outro namespace de PID: o pgrep costuma ve-lo, mas o pkill pode
+# nao alcanca-lo. O `flatpak ps` e o `flatpak kill` respondem por essa parte.
+discord_running() {
+    pgrep -x Discord >/dev/null 2>&1 && return 0
+    pgrep -x DiscordPTB >/dev/null 2>&1 && return 0
+
+    # Um `flatpak ps` so, e nao um por id: isto roda em laco de dois em dois segundos enquanto
+    # o modo temporario espera o Discord fechar.
+    if have flatpak; then
+        local rodando
+        rodando="$(flatpak ps --columns=application 2>/dev/null || true)"
+        case "$rodando" in *com.discordapp.*) return 0 ;; esac
+    fi
+    return 1
+}
+
 stop_discord() {
-    pgrep -x Discord >/dev/null 2>&1 || pgrep -x DiscordPTB >/dev/null 2>&1 || return 0
+    discord_running || return 0
     step "Fechando o Discord"
     pkill -x Discord 2>/dev/null || true
     pkill -x DiscordPTB 2>/dev/null || true
+    if have flatpak; then
+        local id
+        for id in "${FLATPAK_IDS[@]}"; do
+            flatpak kill "$id" >/dev/null 2>&1 || true
+        done
+    fi
 
     local i
     for i in $(seq 1 40); do
         sleep 0.25
-        pgrep -x Discord >/dev/null 2>&1 || pgrep -x DiscordPTB >/dev/null 2>&1 || return 0
+        discord_running || return 0
     done
     fail "O Discord nao fechou. Feche na mao e rode de novo."
 }
@@ -273,6 +380,9 @@ if [ "$MODE" = "uninstall" ]; then
             continue
         fi
         remove_injection "$resources" && ok "$resources voltou ao normal."
+        if id="$(flatpak_app_id "$resources")"; then
+            revoke_flatpak_access "$id" "$INSTALL_DIR"
+        fi
     done
     exit 0
 fi
@@ -289,6 +399,13 @@ for resources in "${FOUND[@]}"; do
     fi
 
     install_patcher
+
+    # Antes do stop_discord de proposito: vale tanto para a injecao nova quanto para a que ja
+    # estava la, que sai por baixo daqui pelo continue.
+    if id="$(flatpak_app_id "$resources")"; then
+        grant_flatpak_access "$id" "$INSTALL_DIR"
+    fi
+
     stop_discord
 
     [ "$state" = "outromod" ] && remove_injection "$resources"
@@ -310,6 +427,15 @@ case " ${FOUND[*]} " in
     *"/app-"*)
         printf '  %sQuando o Discord se atualizar, ele cria uma pasta app-<versao> nova e a%s\n' "$C_DIM" "$C_OFF" >&2
         printf '  %sinjecao fica para tras. Rode este instalador de novo depois de atualizar.%s\n' "$C_DIM" "$C_OFF" >&2 ;;
+esac
+
+# O deploy do flatpak e refeito do zero a cada atualizacao, e a injecao mora dentro dele. Nao
+# da para impedir isso de fora, e nem o proprio bypass consegue se remendar depois: dentro do
+# sandbox a pasta do app e montada somente leitura. So resta avisar antes de acontecer.
+case " ${FOUND[*]} " in
+    *"/flatpak/app/"*)
+        printf '  %sEste Discord e flatpak: um "flatpak update" desfaz a injecao. Quando isso%s\n' "$C_DIM" "$C_OFF" >&2
+        printf '  %sacontecer, rode este instalador de novo.%s\n' "$C_DIM" "$C_OFF" >&2 ;;
 esac
 printf '  %sRegistro em %s/golivebypass.log%s\n' "$C_DIM" "$INSTALL_DIR" "$C_OFF" >&2
 printf '  %sPara desfazer: ./golivebypass-standalone.sh --uninstall%s\n\n' "$C_DIM" "$C_OFF" >&2


### PR DESCRIPTION
## O que muda

Os dois instaladores de Linux passam a funcionar com o Discord instalado por Flatpak, do
sistema (`/var/lib/flatpak`) ou do usuário (`~/.local/share/flatpak`).

Até aqui o README dizia que Flatpak era "somente leitura, **não dá para injetar**", e o
standalone recusava a instalação com essa justificativa. **Isso está errado**, e é o
ponto de partida deste PR.

## Por que dá para injetar

O deploy do Flatpak parece intocável, mas é um diretório comum num sistema de arquivos
comum. A injeção só **renomeia** `app.asar` para `_app.asar` e cria uma pasta ao lado —
nenhum arquivo é reescrito, então os objetos hardlinkados do repositório ostree ficam
intactos.

Não é teoria: o Equilotl (Equicord) e o VencordInstaller (Vencord) já suportam Flatpak há
tempos. Ambos varrem `/var/lib/flatpak/app`, `~/.local/share/flatpak/app` e
`~/.var/app/com.discordapp.*/config/discord/app-*`, e ambos rodam
`flatpak override --filesystem=` para o sandbox enxergar a pasta de build. Ou seja: o
`pnpm inject` já fazia a parte difícil, e era o nosso script que não enxergava o alvo.

O Snap continua de fora, e agora pelo motivo certo: ali o app fica dentro de um squashfs,
que é somente leitura de verdade — nem o root escreve.

## `installer/golivebypass-installer.sh`

- `discord_resources()` acha os deploys de Flatpak e também o layout de bootstrap dentro do
  sandbox. Sem isso o `injected_from_checkout` falhava e o script dizia "a injeção não
  pegou" **mesmo quando ela tinha pegado**.
- `inject_mod` passa `--location` quando só existe um Discord. Com isso dá para saber
  *antes* de rodar se aquele alvo precisa de root, e pedir sudo na hora certa em vez de
  falhar com "permissão negada" e mandar tentar de novo. Se o pnpm comer o `--` antes de
  repassar, cai no `pnpm inject` de sempre.
- `run_inject_root` mantém o `PATH` vivo através do sudo e devolve o dono de `dist/`
  depois. Sem isso o binário do instalador que o pnpm baixa fica como root dentro do
  checkout, e o próximo `pnpm build` sem sudo quebra.
- **`mod_settings_file` era o problema silencioso**: dentro do sandbox o `HOME` é outro, e o
  mod lê `~/.var/app/com.discordapp.Discord/config/Equicord/settings/settings.json`. Escrever
  em `~/.config/Equicord` deixaria o plugin **desligado** logo depois de o instalador
  anunciar que tinha ativado.
- `grant_flatpak_access` reaplica o `flatpak override` também no caminho em que a injeção já
  estava pronta e o script só reinicia o Discord — ali o instalador do mod não roda, então
  ninguém liberaria o sandbox. Confere antes com `flatpak info --show-permissions`, que não
  precisa de root, para não pedir a senha do sudo à toa.
- `start_discord` abre `flatpak run <id>` quando a injeção caiu num Flatpak. Antes, quem
  tivesse um Discord nativo pela metade abriria o nativo, sem o mod, e concluiria que a
  instalação falhou. `stop_discord` ganhou `flatpak ps` e `flatpak kill`.

## `standalone/golivebypass-standalone.sh`

Mesma descoberta, mais a liberação de `~/.local/share/GoLiveBypass` para o sandbox — em
leitura **e escrita**, porque o registro é gravado ali. Removida no `--uninstall`. O
`as_root` já decidia certo pelo `-w`, então a injeção em si não precisou mudar. O aviso de
Flatpak saiu; o de Snap ficou.

## O que foi testado

Contra um Flatpak de sistema real (`com.discordapp.Discord` 1.0.154, Linux Mint 22.3):

- descoberta dos caminhos e derivação do `--location` para os cinco layouts;
- `flatpak_has_access` contra a saída real do `--show-permissions`, incluindo o caso de uma
  entrada negada (`!pasta`), que um `grep` solto aceitaria por engano;
- ciclo completo do standalone — instalar, `--status`, desinstalar, reinstalar por cima — numa
  árvore espelhada, com `flatpak` e `sudo` stubados. Nada foi escrito no Flatpak de verdade.

**Não foi testado:** a chamada real do `pnpm inject`. A máquina de teste não tem Node nem
pnpm, então não deu para confirmar na prática que `pnpm run inject -- --location X` repassa a
flag em vez de comer o `--`. É por isso que os dois caminhos de injeção caem no formato
interativo de sempre quando falham, em vez de confiar nela.

## Ressalva que o usuário passa a ver

Um `flatpak update` refaz o deploy inteiro e leva a injeção junto. Não dá para impedir isso
de fora, e — diferente do caso nativo de `app-<versão>` — o standalone nem consegue se
remendar sozinho depois, porque dentro do sandbox a pasta do app é montada somente leitura.
Os dois scripts e o README avisam.