### PR TITLE
gui: melhor interface no MacOS

### DIFF
--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -204,7 +204,10 @@ function createWindow() {
     autoHideMenuBar: true,
     titleBarStyle: isMac ? "hiddenInset" : "hidden",
     ...(isMac
-      ? { trafficLightPosition: { x: 8, y: 8 } }
+      ? {
+          trafficLightPosition: { x: 8, y: 8 },
+          useContentSize: true,
+        }
       : {
           titleBarOverlay: {
             color: "#1e1f22",

--- a/golive-gui/src/main.ts
+++ b/golive-gui/src/main.ts
@@ -50,8 +50,6 @@ const warningAlert = document.getElementById('warningAlert')!;
 const proxyInput = document.getElementById('proxyInput') as HTMLInputElement;
 const startupToggle = document.getElementById('startupToggle') as HTMLInputElement;
 
-
-
 let currentState = 'INACTIVE';
 
 // O warning do bypass ativo faz o conteudo crescer; a janela e fixa, entao reportamos a altura
@@ -63,8 +61,6 @@ function fitWindowToContent() {
   const height = Math.ceil(container.getBoundingClientRect().height + 1);
   window.api.resizeWindow(height);
 }
-
-
 
 async function updateStatus() {
   try {

--- a/golive-gui/src/style.css
+++ b/golive-gui/src/style.css
@@ -24,20 +24,17 @@ body {
   color: var(--text);
   overflow: hidden;
   user-select: none;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   height: 100vh;
 }
 
-.drag-region {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 32px;
-  -webkit-app-region: drag;
-  z-index: 100;
+#app {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: relative;
 }
 
 .container {
@@ -48,6 +45,8 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 24px;
+  margin: auto 0;
+  flex-shrink: 0;
 }
 
 /* Classe colocada pelo renderer a partir do flag de plataforma do preload. */
@@ -57,6 +56,28 @@ body {
 
 .darwin .container {
   padding-top: 64px;
+}
+
+@media (max-height: 680px) {
+  .container {
+    gap: 24px;
+    padding-top: 32px;
+    padding-bottom: 24px;
+  }
+
+  .darwin .container {
+    padding-top: 56px;
+  }
+}
+
+.drag-region {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 32px;
+  -webkit-app-region: drag;
+  z-index: 100;
 }
 
 .header {


### PR DESCRIPTION
Melhora a interface no macOS adicionando scroll e melhor espaçamento

### Antes
Essa visão era estatica completamente, sem scroll e basicamente sem espaçamento.
<img width="421" height="547" alt="image" src="https://github.com/user-attachments/assets/3f5894f9-29f0-4b1e-85b2-a00cc398b5be" />


### Depois
Espaçamento adicionado
<img width="508" height="647" alt="image" src="https://github.com/user-attachments/assets/dffbe730-43db-4793-b4ef-f8ba12bdecab" />

Temos scroll!

<img width="508" height="647" alt="image" src="https://github.com/user-attachments/assets/61dcd705-a042-420c-bf08-4aa03f7f9f50" />

