### PR TITLE
api: servico Go de bug reports — base para quando houver dominio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@ node_modules/
 dist/
 *.log
 
+# api (Go)
+api/.env
+api/api
+
 # config local do agente
 .commandcode/

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,11 @@
+# Obrigatorias
+GITHUB_TOKEN=ghp_cole_aqui_o_fine_grained_pat
+API_TOKEN=gerar_um_segredo_compartilhado
+
+# Opcionais
+GITHUB_REPO=bezumiya/GoLiveBypass
+ISSUE_LABELS=bug
+PORT=8080
+RATE_LIMIT=60
+MAX_LOG_BYTES=262144
+LOG_LEVEL=info

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,14 @@
+# Imagem de build
+FROM golang:1.25-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/api ./cmd/api
+
+# Imagem final
+FROM scratch
+COPY --from=build /out/api /api
+USER 65534:65534
+EXPOSE 8080
+ENTRYPOINT ["/api"]

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,153 @@
+# GoLiveBypass — API de Bug Reports
+
+API HTTP, em Go, que recebe relatos de bug dos apps do GoLiveBypass e abre
+issues no GitHub. Por enquanto só isto: um endpoint autenticado que transforma
+um relato (título, descrição, log de diagnóstico e metadados) em uma issue.
+
+- **Stack**: Go 1.25+ · [Echo v5](https://github.com/labstack/echo/v5)
+- **Dependência externa**: nenhuma além do Echo (o cliente do GitHub é stdlib)
+
+## Como funciona
+
+```
+app (GUI/standalone, futuro)              API (este serviço)              GitHub
+      │  POST /v1/reports                        │                              │
+      │  Authorization: Bearer <API_TOKEN>       │                              │
+      │  {title, description, log, meta} ───────►│  valida + monta markdown     │
+      │                                          │  POST /repos/{repo}/issues ──►│
+      │  201 {issue_number, issue_url} ◄─────────│◄── 201 {number, html_url}    │
+```
+
+## Setup
+
+1. **Crie um PAT (fine-grained)** em *GitHub → Settings → Developer settings →
+   Fine-grained personal access tokens*, com acesso somente ao repositório
+   alvo (`Repository access → Only select repositories`) e permissão
+   **Issues: write**.
+2. **Crie a label** usada por padrão (`bug`) no repositório alvo — sem ela o
+   GitHub responde 422 e a issue não é criada. A lista vem de `ISSUE_LABELS`.
+3. **Gere o token compartilhado** com os apps (`API_TOKEN`), por exemplo:
+   `openssl rand -hex 32`. Este token será embutido na GUI/standalone quando
+   eles ganharem o botão de reportar bug — se vazar, troque o valor e o
+   segredo embutido nos apps.
+
+## Rodando
+
+```sh
+cd api
+go run ./cmd/api        # exige API_TOKEN e GITHUB_TOKEN no ambiente
+```
+
+Variáveis (todas em `.env.example`):
+
+| Variável | Obrig. | Padrão | Descrição |
+|---|---|---|---|
+| `API_TOKEN` | sim | — | segredo compartilhado com os apps (Bearer) |
+| `GITHUB_TOKEN` | sim | — | PAT com permissão Issues: write no repo alvo |
+| `GITHUB_REPO` | não | `bezumiya/GoLiveBypass` | `owner/repo` da issue |
+| `ISSUE_LABELS` | não | `bug` | labels separadas por vírgula (precisam existir no repo) |
+| `PORT` | não | `8080` | porta HTTP |
+| `RATE_LIMIT` | não | `60` | requisições por minuto por IP |
+| `MAX_LOG_BYTES` | não | `262144` | teto do campo `log` (256 KB) |
+| `LOG_LEVEL` | não | `info` | `debug`, `info`, `warn`, `error` |
+
+### Testar com curl
+
+```sh
+curl -s localhost:8080/healthz
+
+# sem token → 401
+curl -s -X POST localhost:8080/v1/reports -d '{"title":"x"}'
+
+# validação → 400
+curl -s -X POST localhost:8080/v1/reports -H 'Authorization: Bearer <API_TOKEN>' \
+  -d '{"title":""}'
+
+# com token fake → 502 (chega no GitHub e falha na auth) — confirma o fluxo
+API_TOKEN=dev GITHUB_TOKEN=fake GITHUB_REPO=pdl-clay/GoLiveBypass go run ./cmd/api
+curl -s -X POST localhost:8080/v1/reports -H 'Authorization: Bearer dev' \
+  -d '{"title":"Teste","log":"linha do log","meta":{"app":"cli","os":"linux"}}'
+```
+
+### Docker
+
+```sh
+docker build -t golive-api api
+docker run --rm -p 8080:8080 \
+  -e API_TOKEN=... -e GITHUB_TOKEN=... \
+  -e GITHUB_REPO=pdl-clay/GoLiveBypass \
+  golive-api
+```
+
+## Endpoints
+
+### `POST /v1/reports`
+
+Body (JSON):
+
+```json
+{
+  "title": "Go Live não sobe após atualização",
+  "description": "passos de reprodução...",
+  "log": "====\nabrindo | win32 x64 | electron 42...",
+  "meta": { "app": "golive-gui", "version": "1.2.0", "os": "linux x64" }
+}
+```
+
+- `title` — obrigatório, até 200 caracteres (espaços nas bordas são removidos).
+- `description` — opcional, até 8 KB.
+- `log` — opcional; truncado em `MAX_LOG_BYTES`; o conteúdo é neutralizado para
+  não quebrar o bloco de código da issue.
+- `meta` — opcional; pares `chave: valor` exibidos numa tabela na issue.
+
+Resposta `201`:
+
+```json
+{ "issue_number": 123, "issue_url": "https://github.com/.../issues/123" }
+```
+
+### `GET /healthz`
+
+`200 {"status":"ok"}` — sem autenticação, para healthcheck.
+
+## Erros
+
+| Status | Quando | Body |
+|---|---|---|
+| `400` | payload inválido (JSON, title, tamanhos) | `{"error": "..."}` |
+| `401` | token ausente ou errado | `{"error": "..."}` |
+| `413` | corpo acima de 512 KB | `{"error": "..."}` |
+| `429` | rate limit por IP excedido (header `Retry-After`) | `{"error": "..."}` |
+| `404` / `405` | rota/método inexistente | `{"error": "..."}` |
+| `502` | o GitHub recusou (auth, label inexistente, etc.) | detalhe só no log do servidor |
+
+## Operação
+
+- **TLS termina no reverse proxy** (Caddy, nginx, Traefik) — a API não fala
+  TLS sozinha. Atrás do proxy, o rate limit usa o IP real do cliente por
+  `X-Forwarded-For` (o Echo só confia em XFF vindo de IP de loopback ou rede
+  privada).
+- **Rate limit em memória**: suficiente para uma instância; com várias
+  instâncias atrás de um load balancer, cada uma tem a própria contagem e o
+  Redis seria o próximo passo (fora de escopo por enquanto).
+- Desligamento gracioso em `SIGINT`/`SIGTERM` (até 10 s para requisições em
+  andamento).
+
+## Testes
+
+```sh
+cd api
+go vet ./...
+go test ./...
+```
+
+Cobertura: validação do payload e montagem do markdown (`internal/bugreport`),
+cliente GitHub contra um fake HTTP (`internal/gh`), e os endpoints completos
+com auth, rate limit, body limit e erros (`internal/server`).
+
+## Integração futura (fora deste escopo)
+
+A GUI (Electron) e o standalone ganharão um botão **"Reportar bug"** que
+monta o relato — com o `golivebypass.log` e os metadados do sistema — e chama
+`POST /v1/reports` com o `API_TOKEN` embutido. A resposta traz a URL da issue
+para mostrar ao usuário.

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/pdl-clay/GoLiveBypass/api/internal/config"
+	"github.com/pdl-clay/GoLiveBypass/api/internal/gh"
+	"github.com/pdl-clay/GoLiveBypass/api/internal/server"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		slog.Error("configuracao invalida", "err", err)
+		os.Exit(1)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseLevel(cfg.LogLevel)}))
+	slog.SetDefault(logger)
+
+	e := server.New(cfg, gh.New(cfg.GitHubToken, cfg.GitHubRepo), logger)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	sc := echo.StartConfig{
+		Address:         ":" + cfg.Port,
+		HideBanner:      true,
+		HidePort:        true,
+		GracefulTimeout: 10 * time.Second,
+		OnShutdownError: func(err error) { logger.Error("falha no desligamento", "err", err) },
+		BeforeServeFunc: func(s *http.Server) error {
+			s.ReadHeaderTimeout = 5 * time.Second
+			s.IdleTimeout = 60 * time.Second
+			return nil
+		},
+	}
+
+	logger.Info("API de bug reports no ar", "addr", sc.Address, "repo", cfg.GitHubRepo)
+	if err := sc.Start(ctx, e); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Error("servidor encerrado com erro", "err", err)
+		os.Exit(1)
+	}
+	logger.Info("servidor desligado")
+}
+
+func parseLevel(s string) slog.Level {
+	switch s {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,0 +1,7 @@
+module github.com/pdl-clay/GoLiveBypass/api
+
+go 1.26.5
+
+require github.com/labstack/echo/v5 v5.3.1
+
+require golang.org/x/time v0.15.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/labstack/echo/v5 v5.3.1 h1:75maCxkQVGualckLc/5s/ihgpH1a1Dc6AuGWNVNs6bw=
+github.com/labstack/echo/v5 v5.3.1/go.mod h1:4iEGNQiPPZnkfYpNR/L6fINd3NLiGWUD5+eBotFALas=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
+golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
+golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/api/internal/bugreport/report.go
+++ b/api/internal/bugreport/report.go
@@ -1,0 +1,73 @@
+package bugreport
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	MaxTitleLen       = 200
+	MaxDescriptionLen = 8 * 1024
+	logFence          = "````"
+)
+
+type Report struct {
+	Title       string            `json:"title"`
+	Description string            `json:"description"`
+	Log         string            `json:"log"`
+	Meta        map[string]string `json:"meta"`
+}
+
+func (r *Report) Validate(maxLogBytes int64) error {
+	r.Title = strings.TrimSpace(r.Title)
+	switch {
+	case r.Title == "":
+		return fmt.Errorf("title e obrigatorio")
+	case len(r.Title) > MaxTitleLen:
+		return fmt.Errorf("title deve ter no maximo %d caracteres", MaxTitleLen)
+	}
+	if len(r.Description) > MaxDescriptionLen {
+		return fmt.Errorf("description deve ter no maximo %d caracteres", MaxDescriptionLen)
+	}
+	if int64(len(r.Log)) > maxLogBytes {
+		r.Log = r.Log[:maxLogBytes]
+	}
+	return nil
+}
+
+func BuildIssueBody(r Report) string {
+	var b strings.Builder
+	b.WriteString("Relato enviado pela API de bug reports.\n\n")
+
+	if len(r.Meta) > 0 {
+		b.WriteString("**Sistema:**\n\n| | |\n|---|---|\n")
+		keys := make([]string, 0, len(r.Meta))
+		for k := range r.Meta {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(&b, "| %s | %s |\n", tableCell(k), tableCell(r.Meta[k]))
+		}
+		b.WriteString("\n")
+	}
+
+	if d := strings.TrimSpace(r.Description); d != "" {
+		b.WriteString("**Descrição:**\n\n")
+		b.WriteString(d)
+		b.WriteString("\n\n")
+	}
+
+	if l := r.Log; l != "" {
+		b.WriteString("**Log:**\n\n")
+		b.WriteString(logFence + "\n")
+		b.WriteString(strings.ReplaceAll(l, logFence, "```"))
+		b.WriteString("\n" + logFence + "\n")
+	}
+	return b.String()
+}
+
+func tableCell(s string) string {
+	return strings.NewReplacer("|", "\\|", "\n", " ").Replace(s)
+}

--- a/api/internal/bugreport/report_test.go
+++ b/api/internal/bugreport/report_test.go
@@ -1,0 +1,104 @@
+package bugreport
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateTitle(t *testing.T) {
+	long := strings.Repeat("a", MaxTitleLen+1)
+
+	tests := []struct {
+		name    string
+		title   string
+		wantErr bool
+	}{
+		{"titulo normal", "Go Live não sobe", false},
+		{"titulo no limite", strings.Repeat("a", MaxTitleLen), false},
+		{"titulo vazio", "", true},
+		{"titulo so espacos", "   \t ", true},
+		{"titulo longo", long, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rep := &Report{Title: tt.title, Meta: map[string]string{}}
+			err := rep.Validate(262144)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateTrimsTitle(t *testing.T) {
+	rep := &Report{Title: "  título com espaço  "}
+	if err := rep.Validate(262144); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if rep.Title != "título com espaço" {
+		t.Errorf("Title = %q, nao foi feito trim", rep.Title)
+	}
+}
+
+func TestValidateDescriptionTooLong(t *testing.T) {
+	rep := &Report{Title: "t", Description: strings.Repeat("a", MaxDescriptionLen+1)}
+	if err := rep.Validate(262144); err == nil {
+		t.Fatal("Validate() esperava erro com descricao longa")
+	}
+}
+
+func TestValidateTruncatesLog(t *testing.T) {
+	rep := &Report{Title: "t", Log: strings.Repeat("x", 1024)}
+	if err := rep.Validate(100); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if len(rep.Log) != 100 {
+		t.Errorf("Log com %d bytes, want 100", len(rep.Log))
+	}
+}
+
+func TestBuildIssueBodyCompleto(t *testing.T) {
+	rep := Report{
+		Title:       "t",
+		Description: "passo 1\npasso 2",
+		Log:         "linha1\n```\nlinha2",
+		Meta:        map[string]string{"os": "linux x64", "app": "golive-gui", "zebra": "com | pipe"},
+	}
+	body := BuildIssueBody(rep)
+	for _, want := range []string{
+		"**Sistema:**",
+		"| app | golive-gui |",
+		"| os | linux x64 |\n| zebra | com \\| pipe |",
+		"**Descrição:**",
+		"passo 1\npasso 2",
+		"**Log:**",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("corpo sem %q", want)
+		}
+	}
+	if !strings.Contains(body, logFence) {
+		t.Error("corpo sem fence de log")
+	}
+}
+
+func TestBuildIssueBodyLogComFenceInterno(t *testing.T) {
+	rep := Report{Title: "t", Log: "inicio\n````\nmeio ``` fim"}
+	body := BuildIssueBody(rep)
+	if strings.Contains(body, logFence+"\n````") {
+		t.Error("fence interno de 4 backticks nao foi neutralizado")
+	}
+	if !strings.Contains(body, "meio ``` fim") {
+		t.Error("triple backtick original deve continuar intacto dentro do fence de 4")
+	}
+}
+
+func TestBuildIssueBodyVazio(t *testing.T) {
+	body := BuildIssueBody(Report{Title: "t"})
+	if !strings.Contains(body, "API de bug reports") {
+		t.Errorf("corpo minimo sem cabecalho: %q", body)
+	}
+	if strings.Contains(body, "**Sistema:**") || strings.Contains(body, "**Log:**") {
+		t.Errorf("secoes vazias nao deveriam aparecer: %q", body)
+	}
+}

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type Config struct {
+	APIToken    string
+	GitHubToken string
+	GitHubRepo  string
+	Labels      []string
+	Port        string
+	RateLimit   float64
+	MaxLogBytes int64
+	LogLevel    string
+}
+
+func Load() (*Config, error) {
+	cfg := &Config{
+		GitHubRepo:  getenv("GITHUB_REPO", "bezumiya/GoLiveBypass"),
+		Port:        getenv("PORT", "8080"),
+		RateLimit:   getenvFloat("RATE_LIMIT", 60) / 60,
+		MaxLogBytes: getenvInt64("MAX_LOG_BYTES", 262144),
+		LogLevel:    getenv("LOG_LEVEL", "info"),
+	}
+
+	cfg.APIToken = os.Getenv("API_TOKEN")
+	if cfg.APIToken == "" {
+		return nil, errors.New("API_TOKEN e obrigatoria")
+	}
+	cfg.GitHubToken = os.Getenv("GITHUB_TOKEN")
+	if cfg.GitHubToken == "" {
+		return nil, errors.New("GITHUB_TOKEN e obrigatoria")
+	}
+	if !strings.Contains(cfg.GitHubRepo, "/") {
+		return nil, fmt.Errorf("GITHUB_REPO deve estar no formato owner/repo (recebido %q)", cfg.GitHubRepo)
+	}
+	cfg.Labels = splitCSV(getenv("ISSUE_LABELS", "bug"))
+	return cfg, nil
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func getenvInt64(key string, def int64) int64 {
+	v, err := strconv.ParseInt(os.Getenv(key), 10, 64)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+func getenvFloat(key string, def float64) float64 {
+	v, err := strconv.ParseFloat(os.Getenv(key), 64)
+	if err != nil || v <= 0 {
+		return def
+	}
+	return v
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/api/internal/config/config_test.go
+++ b/api/internal/config/config_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLoadDefaults(t *testing.T) {
+	t.Setenv("API_TOKEN", "app-secret")
+	t.Setenv("GITHUB_TOKEN", "gh-secret")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.GitHubRepo != "bezumiya/GoLiveBypass" {
+		t.Errorf("GitHubRepo = %q, want bezumiya/GoLiveBypass", cfg.GitHubRepo)
+	}
+	if cfg.Port != "8080" {
+		t.Errorf("Port = %q, want 8080", cfg.Port)
+	}
+	if cfg.RateLimit != 1 {
+		t.Errorf("RateLimit = %v, want 1 (60/min)", cfg.RateLimit)
+	}
+	if cfg.MaxLogBytes != 262144 {
+		t.Errorf("MaxLogBytes = %d, want 262144", cfg.MaxLogBytes)
+	}
+	if !reflect.DeepEqual(cfg.Labels, []string{"bug"}) {
+		t.Errorf("Labels = %v, want [bug]", cfg.Labels)
+	}
+}
+
+func TestLoadMissingAPIToken(t *testing.T) {
+	t.Setenv("API_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "gh-secret")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() esperava erro com API_TOKEN ausente")
+	}
+}
+
+func TestLoadMissingGitHubToken(t *testing.T) {
+	t.Setenv("API_TOKEN", "app-secret")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() esperava erro com GITHUB_TOKEN ausente")
+	}
+}
+
+func TestLoadInvalidRepo(t *testing.T) {
+	t.Setenv("API_TOKEN", "app-secret")
+	t.Setenv("GITHUB_TOKEN", "gh-secret")
+	t.Setenv("GITHUB_REPO", "sem-barra")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() esperava erro com GITHUB_REPO invalido")
+	}
+}
+
+func TestLoadOverrides(t *testing.T) {
+	t.Setenv("API_TOKEN", "app-secret")
+	t.Setenv("GITHUB_TOKEN", "gh-secret")
+	t.Setenv("GITHUB_REPO", "pdl-clay/GoLiveBypass")
+	t.Setenv("ISSUE_LABELS", "bug, triage , ")
+	t.Setenv("RATE_LIMIT", "120")
+	t.Setenv("PORT", "9090")
+	t.Setenv("MAX_LOG_BYTES", "1000")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.GitHubRepo != "pdl-clay/GoLiveBypass" {
+		t.Errorf("GitHubRepo = %q", cfg.GitHubRepo)
+	}
+	if !reflect.DeepEqual(cfg.Labels, []string{"bug", "triage"}) {
+		t.Errorf("Labels = %v", cfg.Labels)
+	}
+	if cfg.RateLimit != 2 {
+		t.Errorf("RateLimit = %v, want 2", cfg.RateLimit)
+	}
+	if cfg.Port != "9090" {
+		t.Errorf("Port = %q, want 9090", cfg.Port)
+	}
+	if cfg.MaxLogBytes != 1000 {
+		t.Errorf("MaxLogBytes = %d, want 1000", cfg.MaxLogBytes)
+	}
+}
+
+func TestLoadEmptyLabelsFallsBackToBug(t *testing.T) {
+	t.Setenv("API_TOKEN", "app-secret")
+	t.Setenv("GITHUB_TOKEN", "gh-secret")
+	t.Setenv("ISSUE_LABELS", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !reflect.DeepEqual(cfg.Labels, []string{"bug"}) {
+		t.Errorf("Labels = %v, want [bug]", cfg.Labels)
+	}
+}

--- a/api/internal/gh/github.go
+++ b/api/internal/gh/github.go
@@ -1,0 +1,84 @@
+package gh
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	apiBase        = "https://api.github.com"
+	apiAccept      = "application/vnd.github+json"
+	apiVersion     = "2022-11-28"
+	requestTimeout = 10 * time.Second
+)
+
+type Client struct {
+	baseURL string
+	token   string
+	repo    string
+	http    *http.Client
+}
+
+func New(token, repo string) *Client {
+	return &Client{
+		baseURL: apiBase,
+		token:   token,
+		repo:    repo,
+		http:    &http.Client{Timeout: requestTimeout},
+	}
+}
+
+type Issue struct {
+	Title  string   `json:"title"`
+	Body   string   `json:"body"`
+	Labels []string `json:"labels,omitempty"`
+}
+
+type IssueResult struct {
+	Number int    `json:"number"`
+	URL    string `json:"html_url"`
+}
+
+func (c *Client) CreateIssue(ctx context.Context, iss Issue) (IssueResult, error) {
+	payload, err := json.Marshal(iss)
+	if err != nil {
+		return IssueResult{}, fmt.Errorf("serializando issue: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/repos/"+c.repo+"/issues", bytes.NewReader(payload))
+	if err != nil {
+		return IssueResult{}, fmt.Errorf("montando requisicao: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", apiAccept)
+	req.Header.Set("X-GitHub-Api-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "GoLiveBypass-bugreport-api")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return IssueResult{}, fmt.Errorf("chamando a API do GitHub: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		var res IssueResult
+		if err := json.Unmarshal(body, &res); err != nil {
+			return IssueResult{}, fmt.Errorf("decodificando resposta (%s): %w", resp.Status, err)
+		}
+		return res, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return IssueResult{}, fmt.Errorf("autenticacao no GitHub falhou (%s): %s", resp.Status, strings.TrimSpace(string(body)))
+	case http.StatusUnprocessableEntity:
+		return IssueResult{}, fmt.Errorf("GitHub rejeitou a issue (%s) — confira se as labels existem no repo %s: %s", resp.Status, c.repo, strings.TrimSpace(string(body)))
+	default:
+		return IssueResult{}, fmt.Errorf("GitHub respondeu %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+}

--- a/api/internal/gh/github_test.go
+++ b/api/internal/gh/github_test.go
@@ -1,0 +1,104 @@
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newFake(t *testing.T, status int, response string) (*Client, func() (*http.Request, []byte)) {
+	t.Helper()
+	var last *http.Request
+	var lastBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		last = r
+		lastBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		io.WriteString(w, response)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New("tok-secreto", "owner/repo")
+	c.baseURL = srv.URL
+	return c, func() (*http.Request, []byte) { return last, lastBody }
+}
+
+func TestCreateIssueOK(t *testing.T) {
+	c, getReq := newFake(t, http.StatusCreated, `{"number":42,"html_url":"https://github.com/owner/repo/issues/42"}`)
+
+	res, err := c.CreateIssue(context.Background(), Issue{Title: "Bug", Body: "corpo", Labels: []string{"bug"}})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	if res.Number != 42 || res.URL != "https://github.com/owner/repo/issues/42" {
+		t.Errorf("res = %+v", res)
+	}
+
+	req, body := getReq()
+	if req.Method != http.MethodPost {
+		t.Errorf("method = %s, want POST", req.Method)
+	}
+	if req.URL.Path != "/repos/owner/repo/issues" {
+		t.Errorf("path = %s", req.URL.Path)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer tok-secreto" {
+		t.Errorf("Authorization = %q", got)
+	}
+
+	var sent Issue
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("decodificando payload enviado: %v", err)
+	}
+	if sent.Title != "Bug" || sent.Body != "corpo" || len(sent.Labels) != 1 || sent.Labels[0] != "bug" {
+		t.Errorf("payload enviado = %+v", sent)
+	}
+}
+
+func TestCreateIssueAuthError(t *testing.T) {
+	c, _ := newFake(t, http.StatusUnauthorized, `{"message":"Bad credentials"}`)
+
+	_, err := c.CreateIssue(context.Background(), Issue{Title: "t"})
+	if err == nil || !strings.Contains(err.Error(), "autenticacao") {
+		t.Fatalf("err = %v, queria erro de autenticacao", err)
+	}
+}
+
+func TestCreateIssueUnprocessable(t *testing.T) {
+	c, _ := newFake(t, http.StatusUnprocessableEntity, `{"message":"Validation Failed","errors":[{"field":"labels"}]}`)
+
+	_, err := c.CreateIssue(context.Background(), Issue{Title: "t", Labels: []string{"bug"}})
+	if err == nil || !strings.Contains(err.Error(), "labels") {
+		t.Fatalf("err = %v, queria erro mencionando labels", err)
+	}
+}
+
+func TestCreateIssueServerError(t *testing.T) {
+	c, _ := newFake(t, http.StatusInternalServerError, `{"message":"boom"}`)
+
+	_, err := c.CreateIssue(context.Background(), Issue{Title: "t"})
+	if err == nil || !strings.Contains(err.Error(), "GitHub respondeu") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCreateIssueTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New("tok", "owner/repo")
+	c.baseURL = srv.URL
+	c.http.Timeout = 50 * time.Millisecond
+
+	_, err := c.CreateIssue(context.Background(), Issue{Title: "t"})
+	if err == nil {
+		t.Fatal("esperava erro de timeout")
+	}
+}

--- a/api/internal/server/auth.go
+++ b/api/internal/server/auth.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"crypto/subtle"
+
+	"github.com/labstack/echo/v5"
+	"github.com/labstack/echo/v5/middleware"
+)
+
+func authMiddleware(token string) echo.MiddlewareFunc {
+	return middleware.KeyAuthWithConfig(middleware.KeyAuthConfig{
+		Validator: func(_ *echo.Context, key string, _ middleware.ExtractorSource) (bool, error) {
+			return subtle.ConstantTimeCompare([]byte(key), []byte(token)) == 1, nil
+		},
+	})
+}

--- a/api/internal/server/handlers.go
+++ b/api/internal/server/handlers.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/pdl-clay/GoLiveBypass/api/internal/bugreport"
+	"github.com/pdl-clay/GoLiveBypass/api/internal/config"
+	"github.com/pdl-clay/GoLiveBypass/api/internal/gh"
+)
+
+type IssueCreator interface {
+	CreateIssue(ctx context.Context, iss gh.Issue) (gh.IssueResult, error)
+}
+
+type handler struct {
+	cfg    *config.Config
+	issues IssueCreator
+}
+
+func (h *handler) createReport(c *echo.Context) error {
+	var rep bugreport.Report
+	if err := c.Bind(&rep); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "payload invalido")
+	}
+	if err := rep.Validate(h.cfg.MaxLogBytes); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	res, err := h.issues.CreateIssue(c.Request().Context(), gh.Issue{
+		Title:  rep.Title,
+		Body:   bugreport.BuildIssueBody(rep),
+		Labels: h.cfg.Labels,
+	})
+	if err != nil {
+		c.Logger().Error("falha ao criar issue no github", "err", err, "repo", h.cfg.GitHubRepo)
+		return echo.NewHTTPError(http.StatusBadGateway, "falha ao criar a issue no GitHub")
+	}
+
+	return c.JSON(http.StatusCreated, map[string]any{
+		"issue_number": res.Number,
+		"issue_url":    res.URL,
+	})
+}
+
+func (h *handler) health(c *echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/api/internal/server/server.go
+++ b/api/internal/server/server.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+	"github.com/labstack/echo/v5/middleware"
+
+	"github.com/pdl-clay/GoLiveBypass/api/internal/config"
+)
+
+func New(cfg *config.Config, issues IssueCreator, logger *slog.Logger) *echo.Echo {
+	e := echo.NewWithConfig(echo.Config{NoGroupAutoRegister404Routes: true})
+	e.Logger = logger
+	e.HTTPErrorHandler = echo.DefaultHTTPErrorHandler(false)
+	e.IPExtractor = echo.ExtractIPFromXFFHeader(echo.TrustLoopback(true), echo.TrustPrivateNet(true))
+
+	e.Use(middleware.Recover())
+	e.Use(middleware.RequestLogger())
+
+	h := &handler{cfg: cfg, issues: issues}
+	e.GET("/healthz", h.health)
+
+	store := middleware.NewRateLimiterMemoryStore(cfg.RateLimit)
+	v1 := e.Group("/v1",
+		authMiddleware(cfg.APIToken),
+		middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
+			Store: store,
+			DenyHandler: func(c *echo.Context, _ string, _ error) error {
+				c.Response().Header().Set("Retry-After", "1")
+				return echo.NewHTTPError(http.StatusTooManyRequests, "rate limit excedido, tente de novo em instantes")
+			},
+		}),
+		middleware.BodyLimit(512*1024),
+	)
+	v1.POST("/reports", h.createReport)
+
+	return e
+}

--- a/api/internal/server/server_test.go
+++ b/api/internal/server/server_test.go
@@ -1,0 +1,191 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/pdl-clay/GoLiveBypass/api/internal/config"
+	"github.com/pdl-clay/GoLiveBypass/api/internal/gh"
+)
+
+type fakeIssues struct {
+	got gh.Issue
+	res gh.IssueResult
+	err error
+}
+
+func (f *fakeIssues) CreateIssue(_ context.Context, iss gh.Issue) (gh.IssueResult, error) {
+	f.got = iss
+	return f.res, f.err
+}
+
+func newTestApp(t *testing.T, cfg *config.Config, f *fakeIssues) *echo.Echo {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return New(cfg, f, logger)
+}
+
+func testConfig() *config.Config {
+	return &config.Config{
+		APIToken:    "segredo",
+		GitHubToken: "gh",
+		GitHubRepo:  "owner/repo",
+		Labels:      []string{"bug"},
+		Port:        "8080",
+		RateLimit:   1000,
+		MaxLogBytes: 262144,
+		LogLevel:    "info",
+	}
+}
+
+func do(t *testing.T, e *echo.Echo, method, path, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHealthz(t *testing.T) {
+	e := newTestApp(t, testConfig(), &fakeIssues{})
+	rec := do(t, e, http.MethodGet, "/healthz", "", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"status":"ok"}` {
+		t.Errorf("body = %s", got)
+	}
+}
+
+func TestCreateReportHappyPath(t *testing.T) {
+	f := &fakeIssues{res: gh.IssueResult{Number: 42, URL: "https://github.com/owner/repo/issues/42"}}
+	e := newTestApp(t, testConfig(), f)
+
+	body := `{"title":"  Go Live não sobe  ","description":"reproduz assim","log":"linha1\n` + "````" + `\nlinha2","meta":{"os":"linux x64"}}`
+	rec := do(t, e, http.MethodPost, "/v1/reports", "segredo", body)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (body = %s)", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Number int    `json:"issue_number"`
+		URL    string `json:"issue_url"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decodificando resposta: %v", err)
+	}
+	if out.Number != 42 || out.URL != "https://github.com/owner/repo/issues/42" {
+		t.Errorf("resposta = %+v", out)
+	}
+
+	if f.got.Title != "Go Live não sobe" {
+		t.Errorf("title enviado = %q (esperado sem espacos)", f.got.Title)
+	}
+	if len(f.got.Labels) != 1 || f.got.Labels[0] != "bug" {
+		t.Errorf("labels enviadas = %v", f.got.Labels)
+	}
+	if !strings.Contains(f.got.Body, "| os | linux x64 |") {
+		t.Error("corpo sem metadados")
+	}
+	if !strings.Contains(f.got.Body, "````") {
+		t.Error("corpo sem fence do log")
+	}
+}
+
+func TestCreateReportNoAuth(t *testing.T) {
+	e := newTestApp(t, testConfig(), &fakeIssues{})
+	rec := do(t, e, http.MethodPost, "/v1/reports", "", `{"title":"x"}`)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestCreateReportBadToken(t *testing.T) {
+	e := newTestApp(t, testConfig(), &fakeIssues{})
+	rec := do(t, e, http.MethodPost, "/v1/reports", "errado", `{"title":"x"}`)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestCreateReportInvalidPayload(t *testing.T) {
+	e := newTestApp(t, testConfig(), &fakeIssues{})
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"json malformado", `{"title":`},
+		{"titulo vazio", `{"title":""}`},
+		{"payload nao-json", `isso nao e json`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := do(t, e, http.MethodPost, "/v1/reports", "segredo", tt.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body = %s)", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestCreateReportGitHubFalha(t *testing.T) {
+	f := &fakeIssues{err: context.DeadlineExceeded}
+	e := newTestApp(t, testConfig(), f)
+
+	rec := do(t, e, http.MethodPost, "/v1/reports", "segredo", `{"title":"x"}`)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "DeadlineExceeded") {
+		t.Errorf("resposta vazou detalhe interno: %s", rec.Body.String())
+	}
+}
+
+func TestRateLimit(t *testing.T) {
+	cfg := testConfig()
+	cfg.RateLimit = 0.000_001 // 1 token de burst, refil praticamente nulo
+	e := newTestApp(t, cfg, &fakeIssues{res: gh.IssueResult{Number: 1, URL: "u"}})
+
+	first := do(t, e, http.MethodPost, "/v1/reports", "segredo", `{"title":"x"}`)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("primeira chamada: status = %d, want 201", first.Code)
+	}
+	second := do(t, e, http.MethodPost, "/v1/reports", "segredo", `{"title":"x"}`)
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("segunda chamada: status = %d, want 429", second.Code)
+	}
+	if got := second.Header().Get("Retry-After"); got != "1" {
+		t.Errorf("Retry-After = %q, want 1", got)
+	}
+}
+
+func TestBodyLimit(t *testing.T) {
+	e := newTestApp(t, testConfig(), &fakeIssues{})
+	big := `{"title":"` + strings.Repeat("a", 512*1024) + `"}`
+	rec := do(t, e, http.MethodPost, "/v1/reports", "segredo", big)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", rec.Code)
+	}
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	e := newTestApp(t, testConfig(), &fakeIssues{})
+	rec := do(t, e, http.MethodGet, "/v1/reports", "segredo", "")
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}


### PR DESCRIPTION
## O que é

Serviço HTTP em Go (Echo v5) que recebe relatos de bug dos apps do GoLiveBypass e abre issues no GitHub. **É a base para o deploy quando houver um domínio**: a API já está pronta para rodar — faltam apenas o reverse proxy/TLS, o botão "Reportar bug" na GUI/standalone e apontar `GITHUB_REPO` para o repositório de destino.

## O que entrega

- `POST /v1/reports` — payload `{title, description, log, meta}` validado, log truncado em `MAX_LOG_BYTES` (256 KB) e neutralizado para não quebrar o markdown; resposta `201` com `issue_number`/`issue_url`
- `GET /healthz` — healthcheck sem auth
- Segurança: `Bearer` compartilhado com os apps (compare em tempo constante) + rate limit por IP (memória) + body limit de 512 KB
- Config toda via env (`GITHUB_TOKEN`, `GITHUB_REPO`, `ISSUE_LABELS`, `PORT`, `RATE_LIMIT`, ...)
- Dockerfile multi-stage (imagem mínima, usuário não-root), README de operação (setup do PAT fine-grained, label `bug`, curl, shutdown gracioso)
- Testes: validação do payload/markdown, cliente GitHub contra fake HTTP (201/401/422/timeout), endpoints completos (200/400/401/405/413/429/502)

## Por que agora

A GUI e o standalone já geram o log de diagnóstico (`golivebypass.log`); a API é a ponta que transforma esse relato em issue quando os apps ganharem o botão de reportar. O desenho atual (token compartilhado + rate limit) já protege o endpoint público de spam antes de o domínio existir.

## Próximos passos (fora do escopo)

1. Deploy atrás de reverse proxy com TLS (documentado no README)
2. Botão "Reportar bug" na GUI (Electron) e no standalone, chamando `POST /v1/reports` com o log e os metadados
3. Ajustar `GITHUB_REPO` para o repositório de destino