### PR TITLE
standalone: libera flatpak com --user primeiro e pkexec no lugar do sudo (Fedora KDE)

### DIFF
--- a/diagnostico.sh
+++ b/diagnostico.sh
@@ -1,0 +1,241 @@
+#!/bin/sh
+#
+# Diagnostico do GoLiveBypass para Linux
+#
+# Coleta tudo o que ajuda a achar por que o bypass falhou: ambiente (distro,
+# desktop, sessao, init), flatpak (versao, permissoes, overrides), TODOS os
+# Discords instalados (nativo + flatpak + canary/ptb), a pasta do bypass com
+# os logs e a configuracao (com a senha do proxy mascarada), processos e um
+# teste de saida de rede.
+#
+# Uso:
+#   sh diagnostico.sh
+#
+# A saida vai para a tela e tambem para ~/golivebypass-diagnostico-<data>.txt
+# — anexe esse arquivo (ou cole a saida) no relato do problema.
+
+OUT="$HOME/golivebypass-diagnostico-$(date +%Y%m%d-%H%M%S).txt"
+mkdir -p "$HOME" 2>/dev/null || true
+
+{
+# ------------------------------------------------------------------ cabecalho
+echo "================================================================"
+echo " GoLiveBypass - diagnostico"
+echo " gerado em: $(date '+%Y-%m-%d %H:%M:%S %Z')"
+echo " maquina:   $(hostname 2>/dev/null || echo '?')"
+echo " usuario:   $(id -un 2>/dev/null) (uid=$(id -u 2>/dev/null))"
+echo "================================================================"
+
+secao() { echo; echo "===== $1 ====="; }
+
+# ------------------------------------------------------------ 1. sistema
+secao "1. Sistema"
+if [ -r /etc/os-release ]; then
+    sed -n 's/^\(PRETTY_NAME\|VERSION_ID\|ID\)=/\1=/p' /etc/os-release | tr -d '"'
+else
+    echo "sem /etc/os-release"
+fi
+uname -a 2>/dev/null
+echo "desktop:  ${XDG_CURRENT_DESKTOP:-nao definido}"
+echo "sessao:   ${XDG_SESSION_TYPE:-nao definido} (WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-vazio}, DISPLAY=${DISPLAY:-vazio})"
+echo "init (pid 1): $(ps -p 1 -o comm= 2>/dev/null || echo '?')"
+if command -v systemctl >/dev/null 2>&1; then
+    echo "systemd:  presente (systemctl)"
+elif command -v rc-service >/dev/null 2>&1; then
+    echo "openrc:   presente (rc-service)"
+fi
+
+# ------------------------------------------------------------ 2. ferramentas
+secao "2. Ferramentas disponiveis"
+for cmd in sudo pkexec flatpak curl sh dash bash; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+        echo "$cmd: $(command -v "$cmd")"
+    else
+        echo "$cmd: AUSENTE"
+    fi
+done
+if command -v sudo >/dev/null 2>&1; then
+    if sudo -n true 2>/dev/null; then
+        echo "sudo: NOPASSWD funcionando"
+    else
+        echo "sudo: presente, mas PEDE SENHA (falha sem TTY/sem senha)"
+    fi
+fi
+
+# ------------------------------------------------------------ 3. flatpak
+secao "3. Flatpak"
+if command -v flatpak >/dev/null 2>&1; then
+    flatpak --version 2>&1
+    echo
+    echo "--- apps do Discord instalados (flatpak list):"
+    flatpak list --app 2>/dev/null | grep -i discord || echo "(nenhum discord flatpak na lista)"
+    echo
+    for id in com.discordapp.Discord com.discordapp.DiscordPTB com.discordapp.DiscordCanary; do
+        if flatpak info "$id" >/dev/null 2>&1 || flatpak info --user "$id" >/dev/null 2>&1; then
+            echo "### $id"
+            if flatpak info --user "$id" >/dev/null 2>&1; then
+                echo "  instalacao: USUARIO (--user)"
+            else
+                echo "  instalacao: SISTEMA"
+            fi
+            echo "  --- show-permissions (filesystems):"
+            flatpak info --show-permissions "$id" 2>&1 | sed -n 's/^filesystems=//p' | tr ';' '\n' | sed 's/^/    /'
+            echo "  --- override atual:"
+            flatpak override --show "$id" 2>&1 | sed 's/^/    /'
+            echo "  --- onde o app esta:"
+            flatpak info --show-location "$id" 2>&1 | sed 's/^/    /'
+        fi
+    done
+else
+    echo "flatpak AUSENTE — o Discord por flatpak nao esta em uso"
+fi
+
+# ------------------------------------------------------------ 4. Discords instalados
+secao "4. Discords instalados (todos os lugares possiveis)"
+found=0
+check_resources() {
+    # $1 = caminho de resources
+    [ -d "$1" ] || return
+    found=$((found + 1))
+    echo
+    echo "### $1"
+    if [ -f "$1/_app.asar" ]; then
+        echo "  _app.asar: EXISTE (original guardado por alguem)"
+        if [ -f "$1/app.asar/index.js" ] && grep -q "golivebypass" "$1/app.asar/index.js" 2>/dev/null; then
+            echo "  injecao:   NOSSA (GoLiveBypass)"
+        else
+            echo "  injecao:   OUTRO MOD (app.asar e pasta, index.js sem golivebypass)"
+        fi
+    elif [ -f "$1/app.asar" ] && [ ! -d "$1/app.asar" ]; then
+        echo "  injecao:   VANILLA (app.asar original)"
+    elif [ -d "$1/app.asar" ]; then
+        echo "  injecao:   PASTA app.asar sem _app.asar (mod ativo)"
+    else
+        echo "  sem app.asar/_app.asar"
+    fi
+    ls -la "$1/app.asar" "$1/_app.asar" 2>/dev/null | sed 's/^/  /'
+    echo "  settings.json local: $([ -f "$1/settings.json" ] && echo EXISTE || echo nao)"
+    [ -f "$1/settings.json" ] && sed 's/^/    /' "$1/settings.json"
+}
+
+base="${XDG_CONFIG_HOME:-$HOME/.config}"
+# bootstrap novo do Discord (app baixado no HOME)
+for sub in "$base"/discord/app-*/resources "$base"/discordptb/app-*/resources "$base"/discordcanary/app-*/resources; do
+    check_resources "$sub"
+done
+# instalacoes classicas
+for raiz in \
+    /usr/share/discord /usr/share/discord-ptb /usr/share/discord-canary \
+    /usr/lib/discord /usr/lib/discord-ptb /usr/lib/discord-canary /usr/lib64/discord \
+    /opt/discord /opt/Discord /opt/discord-ptb /opt/discord-canary \
+    /usr/local/share/discord \
+    "$HOME/.local/share/discord" "$HOME/Discord" "$HOME/discord"
+do
+    [ -d "$raiz" ] || continue
+    check_resources "$raiz/resources"
+    check_resources "$raiz"
+done
+# flatpak (sistema e usuario)
+for raiz in /var/lib/flatpak/app "${XDG_DATA_HOME:-$HOME/.local/share}/flatpak/app"; do
+    [ -d "$raiz" ] || continue
+    for sub in "$raiz"/com.discordapp.*/current/active/files/*/resources; do
+        check_resources "$sub"
+    done
+done
+# flatpak do usuario (HOME do discord sandbox)
+for id in com.discordapp.Discord com.discordapp.DiscordPTB com.discordapp.DiscordCanary; do
+    for sub in "$HOME/.var/app/$id"/config/discord*/app-*/resources; do
+        check_resources "$sub"
+    done
+done
+
+if [ "$found" -eq 0 ]; then
+    echo "NENHUM Discord encontrado em lugar nenhum!"
+elif [ "$found" -gt 1 ]; then
+    echo
+    echo ">>> ATENCAO: $found instalacoes de Discord encontradas — pode haver conflito."
+fi
+
+# ------------------------------------------------------------ 5. pasta do bypass
+INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/GoLiveBypass"
+secao "5. Pasta do bypass: $INSTALL_DIR"
+if [ -d "$INSTALL_DIR" ]; then
+    echo "--- conteudo:"
+    ls -la "$INSTALL_DIR" 2>/dev/null | sed 's/^/  /'
+    echo
+    echo "--- settings.json (senha do proxy mascarada):"
+    if [ -f "$INSTALL_DIR/settings.json" ]; then
+        # mascara user:senha@ -> user:***@ para nunca vazar credencial
+        sed -E 's#(://[^:/@]+:)[^@]*@#\1***@#g' "$INSTALL_DIR/settings.json" 2>/dev/null | sed 's/^/  /'
+        echo "  (permissao: $(stat -c '%a' "$INSTALL_DIR/settings.json" 2>/dev/null || echo '?'))"
+    else
+        echo "  NAO EXISTE"
+    fi
+    echo
+    echo "--- state.json (saida guardada, sem proxy):"
+    if [ -f "$INSTALL_DIR/state.json" ]; then
+        cat "$INSTALL_DIR/state.json" 2>/dev/null | sed 's/^/  /'
+    else
+        echo "  NAO EXISTE"
+    fi
+    echo
+    echo "--- golivebypass.log (ultimas 120 linhas):"
+    if [ -f "$INSTALL_DIR/golivebypass.log" ]; then
+        echo "  (tamanho: $(stat -c '%s' "$INSTALL_DIR/golivebypass.log" 2>/dev/null) bytes, modificado: $(stat -c '%y' "$INSTALL_DIR/golivebypass.log" 2>/dev/null | cut -d. -f1))"
+        echo "  ------------------------------------------------------------"
+        tail -120 "$INSTALL_DIR/golivebypass.log" 2>/dev/null | sed 's/^/  /'
+        echo "  ------------------------------------------------------------"
+    else
+        echo "  NAO EXISTE — o bypass nunca rodou, ou o log esta em outro lugar"
+    fi
+else
+    echo "NAO EXISTE — o bypass nunca foi ativado por este usuario"
+fi
+
+# ------------------------------------------------------------ 6. processos
+secao "6. Processos do Discord"
+ps -eo pid,comm,args 2>/dev/null | grep -iE "discord|golive" | grep -v grep | sed 's/^/  /' || echo "  nenhum processo Discord rodando"
+if command -v flatpak >/dev/null 2>&1; then
+    echo "--- flatpak ps:"
+    flatpak ps --columns=application,pid 2>/dev/null | grep -i discord | sed 's/^/  /' || echo "  nenhum flatpak Discord rodando"
+fi
+
+# ------------------------------------------------------------ 7. autostart
+secao "7. Autostart (iniciar com o sistema)"
+if [ -f "$HOME/.config/autostart/golivebypass.desktop" ]; then
+    echo "EXISTE:"
+    cat "$HOME/.config/autostart/golivebypass.desktop" 2>/dev/null | sed 's/^/  /'
+else
+    echo "nao configurado"
+fi
+
+# ------------------------------------------------------------ 8. rede
+secao "8. Saida de rede (para saber se o trafego sai do Brasil)"
+if command -v curl >/dev/null 2>&1; then
+    echo "--- cloudflare trace (mostra o pais de saida, loc=):"
+    curl -s --max-time 10 https://cloudflare.com/cdn-cgi/trace 2>&1 | grep -E "^(ip|loc|colo)=" | sed 's/^/  /' || echo "  falhou ao consultar cloudflare"
+    echo "--- gateway do discord responde? (sem proxy):"
+    curl -s -o /dev/null -w "  http_code=%{http_code} tempo=%{time_total}s\n" --max-time 10 https://gateway.discord.gg 2>&1 || echo "  falhou"
+else
+    echo "curl ausente — nao da para testar a rede"
+fi
+
+# ------------------------------------------------------------ 9. como rodar a GUI com log
+secao "9. Para capturar o erro da GUI no terminal"
+echo "  Rode o AppImage pelo terminal (extrai sem FUSE, como o README manda):"
+echo
+echo "    ./GoLiveBypass.AppImage --appimage-extract-and-run 2>&1 | tee gui.log"
+echo
+echo "  O stderr da GUI (Electron) vai para o terminal — inclusive o erro de"
+echo "  ativacao que aparece so no popup. Cole o gui.log junto com este arquivo."
+
+echo
+echo "================================================================"
+echo " Fim do diagnostico."
+echo " Arquivo salvo em: $OUT"
+echo "================================================================"
+} 2>&1 | tee "$OUT"
+
+echo
+echo "Envie o arquivo abaixo (ou cole a saida) no relato do problema:"
+echo "  $OUT"

--- a/standalone/golivebypass-standalone.sh
+++ b/standalone/golivebypass-standalone.sh
@@ -80,6 +80,26 @@ done
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
+# Roda um comando como root. O sudo e o padrao, mas em desktops com polkit (Fedora KDE/GNOME,
+# Ubuntu com sudo desativado) ele falha sem TTY ou sem senha configurada — e o pkexec mostra o
+# dialogo grafico do sistema. Tentar os dois cobre os dois mundos; quem falhar, avisa.
+elevate() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    elif have sudo && sudo -n true 2>/dev/null; then
+        # NOPASSWD: sudo direto, sem dialogo.
+        sudo "$@"
+    elif have pkexec; then
+        # Sem sudo sem senha, o dialogo do polkit (KDE/GNOME) resolve.
+        pkexec "$@"
+    elif have sudo; then
+        # Ultimo caso: sudo interativo (terminal). Sem TTY ele falha e o chamador avisa.
+        sudo "$@"
+    else
+        return 127
+    fi
+}
+
 # Ler campo a campo em vez de dar source: /etc/os-release e shell valido, e um arquivo torto
 # executaria comando neste script, que logo depois chama sudo.
 os_field() {
@@ -218,11 +238,16 @@ grant_flatpak_access() {
     have flatpak || return 0
     flatpak_has_access "$id" "$dir" && return 0
 
-    if flatpak_is_user_install "$id"; then
-        flatpak override --user "$id" --filesystem="$dir" >/dev/null 2>&1 && return 0
-    else
+    # O override --user vale para app do sistema tambem (o override do usuario tem prioridade
+    # sobre o do sistema) e nao precisa de root. So cai para o sistema quando o --user falha:
+    # no Fedora KDE o sudo/pkexec costuma falhar sem TTY, e este caminho resolve sem dialogo.
+    if flatpak override --user "$id" --filesystem="$dir" >/dev/null 2>&1; then
+        flatpak_has_access "$id" "$dir" && return 0
+    fi
+
+    if ! flatpak_is_user_install "$id"; then
         step "Liberando $dir para o $id"
-        sudo flatpak override "$id" --filesystem="$dir" >/dev/null 2>&1 && return 0
+        elevate flatpak override "$id" --filesystem="$dir" >/dev/null 2>&1 && return 0
     fi
 
     warn "Nao consegui liberar $dir para o $id. Se o Discord abrir em branco, rode:"
@@ -235,10 +260,10 @@ revoke_flatpak_access() {
     local id="$1" dir="$2"
     have flatpak || return 0
 
-    if flatpak_is_user_install "$id"; then
-        flatpak override --user "$id" --nofilesystem="$dir" >/dev/null 2>&1 || true
-    else
-        sudo flatpak override "$id" --nofilesystem="$dir" >/dev/null 2>&1 || true
+    # Mesma logica do grant: o --user vale para app do sistema e nao precisa de root.
+    flatpak override --user "$id" --nofilesystem="$dir" >/dev/null 2>&1 || true
+    if ! flatpak_is_user_install "$id"; then
+        elevate flatpak override "$id" --nofilesystem="$dir" >/dev/null 2>&1 || true
     fi
     return 0
 }
@@ -286,8 +311,8 @@ as_root() {
         "$@"
     else
         local dir="$1"; shift
-        step "Preciso do sudo para escrever em $dir"
-        sudo "$@"
+        step "Preciso de privilegios para escrever em $dir"
+        elevate "$@"
     fi
 }
 

--- a/tests/test-posix.sh
+++ b/tests/test-posix.sh
@@ -176,6 +176,37 @@ else
     ok "proxy invalido rejeitado (RC!=0)"
 fi
 
+# elevate: sem sudo NOPASSWD, o pkexec (polkit) assume — o caso do Fedora KDE/GNOME
+# onde o sudo falha sem TTY. Simula com um pkexec fake que registra a chamada.
+ELEVATE_HOME="$(mktemp -d)"
+mkdir -p "$ELEVATE_HOME/bin"
+cat > "$ELEVATE_HOME/bin/pkexec" <<'PKEXEC_EOF'
+#!/bin/sh
+echo "PKEXEC:$*" >> /tmp/elevate-used
+exec "$@"
+PKEXEC_EOF
+chmod +x "$ELEVATE_HOME/bin/pkexec"
+# extrai so as funcoes have/elevate do script (ate o banner final) para nao rodar o fluxo
+ELEVATE_HARNESS="$(mktemp)"
+awk '/^aviso_empacotado$/{exit} {print}' "$REPO/standalone/golivebypass-standalone.sh" > "$ELEVATE_HARNESS"
+cat >> "$ELEVATE_HARNESS" <<'H_EOF'
+elevate sh -c "echo elevado > /tmp/fakehome/ok"
+[ -f /tmp/fakehome/ok ] && grep -q "PKEXEC:sh" /tmp/elevate-used
+H_EOF
+if "$RUNTIME" run --rm -u 1000:1000 \
+    -v "$ELEVATE_HARNESS:/t.sh:ro" \
+    -v "$ELEVATE_HOME/bin:/tmp/fakebin:ro" \
+    -v "$ELEVATE_HOME:/tmp/fakehome" \
+    fedora:latest sh -c '
+    export PATH=/tmp/fakebin:$PATH
+    sh /t.sh
+' >/dev/null 2>&1; then
+    ok "elevate cai para pkexec sem sudo NOPASSWD (fedora)"
+else
+    bad "elevate nao usou pkexec sem sudo NOPASSWD"
+fi
+rm -rf "$ELEVATE_HOME" "$ELEVATE_HARNESS"
+
 rm -f "$HARNESS"
 
 # --------------------------------------------------------------------------- shells extras (zsh/ksh/mksh)


### PR DESCRIPTION
## Problema

No Fedora KDE (flatpak do Discord do sistema), a ativação falhava com:

```
[!] Nao consegui liberar ~/.local/share/GoLiveBypass para o com.discordapp.Discord.
```

O `sudo flatpak override` morria sem TTY/senha, o override nunca era aplicado, o Discord abria em branco (o `index.js` injetado faz `require` de um caminho que o sandbox não enxerga) e o bypass nunca rodava (sem `golivebypass.log`).

## Correção

1. **`flatpak override --user` primeiro** em `grant_flatpak_access`/`revoke_flatpak_access`: o override do usuário vale para app do sistema também e **não precisa de root**. Só cai para elevação quando o `--user` falha.
2. **Helper `elevate`** (novo): `sudo` NOPASSWD → `pkexec` (diálogo polkit do KDE/GNOME) → `sudo` interativo. Usado no grant, revoke e `as_root`.

## Testes

- `test-posix.sh` ganhou caso novo: sem sudo NOPASSWD, o `elevate` cai para o `pkexec` (validado com um pkexec fake num container Fedora, usuário não-root). Suite completa: 53/53 OK.
- Cenário reproduzido em container: flatpak do sistema + `--user` → `GRANT_RC=0` sem tocar no sistema.

## Também nesta branch

- `diagnostico.sh`: script único que o usuário roda para coletar ambiente, flatpak, todas as instalações de Discord (nativo + flatpak + bootstrap do sandbox), estado da injeção, permissões do flatpak, logs e rede — foi o que revelou a causa raiz no Fedora (override vazio + 2 instalações de Discord).