### PR TITLE
gui: auto-update via GitHub Releases (Windows portable, AppImage, macOS assinado)

### DIFF
--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -1,7 +1,9 @@
 name: build-gui
 
 # Manual de proposito: roda quando a gente dispara para uma tag de release, constroi os
-# tres artefatos da GUI (exe Windows, AppImage Linux, dmg/zip macOS) e anexa na release.
+# tres artefatos da GUI (exe Windows, AppImage Linux, dmg/zip macOS) e publica na release
+# com o metadata do auto-update (latest*.yml). O electron-builder publica direto na
+# release do GitHub — o app consulta a mesma release para se atualizar sozinho.
 # Mac e Linux nao compilam no Windows, entao eles nascem aqui.
 on:
   workflow_dispatch:
@@ -26,11 +28,10 @@ jobs:
           node-version: 22
       - run: npm ci
         working-directory: golive-gui
-      - run: npm run build:win
+      # --publish always: gera o GoLiveBypass.exe + latest.yml e faz upload na release
+      # (o GH_TOKEN do workflow vira o GH_TOKEN que o electron-builder usa).
+      - run: npm run publish:win
         working-directory: golive-gui
-      - name: Publica o exe na release
-        working-directory: golive-gui
-        run: gh release upload ${{ inputs.tag }} dist-app/GoLiveBypass.exe --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -45,11 +46,8 @@ jobs:
           node-version: 22
       - run: npm ci
         working-directory: golive-gui
-      - run: npm run build:linux
+      - run: npm run publish:linux
         working-directory: golive-gui
-      - name: Publica a AppImage na release
-        working-directory: golive-gui
-        run: gh release upload ${{ inputs.tag }} dist-app/*.AppImage --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -64,12 +62,13 @@ jobs:
           node-version: 22
       - run: npm ci
         working-directory: golive-gui
-      - run: npm run build:mac
+      # Com CSC_LINK/CSC_KEY_PASSWORD o electron-builder assina o app; sem eles, builda
+      # sem assinatura (auto-update do Mac so funciona com app assinado).
+      - run: npm run publish:mac
         working-directory: golive-gui
-      - name: Publica dmg e zip na release
-        working-directory: golive-gui
-        run: |
-          gh release upload ${{ inputs.tag }} dist-app/GoLiveBypass.dmg --clobber
-          gh release upload ${{ inputs.tag }} dist-app/GoLiveBypass.zip --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}

--- a/golive-gui/UPDATER.md
+++ b/golive-gui/UPDATER.md
@@ -1,0 +1,155 @@
+# Auto-update do GoLiveBypass — guia do mantenedor
+
+O app se atualiza sozinho consultando as **releases do GitHub** (`api.github.com`),
+sem servidor intermediário. Este documento explica como configurar, publicar e
+testar — inclui o que é obrigatório para o auto-update funcionar em cada SO.
+
+## Como funciona
+
+| SO | Mecanismo | Requisito |
+|----|-----------|-----------|
+| Windows | Updater **portable** próprio (`electron/updater.ts`): consulta a release, baixa o `.exe` novo, substitui via `PORTABLE_EXECUTABLE_FILE` e reabre | Nenhum (não precisa assinar) |
+| Linux | `electron-updater` nativo (AppImageUpdater) com **download diferencial** (blockMap) | Nenhum |
+| macOS | `electron-updater` nativo (MacUpdater, dmg/zip) | **Obrigatório: app assinado** (sem assinatura o download falha) |
+
+O `publish` está configurado em `golive-gui/package.json`:
+
+```json
+"publish": {
+  "provider": "github",
+  "owner": "bezumiya",
+  "repo": "GoLiveBypass",
+  "releaseType": "release"
+}
+```
+
+## Publicar uma release (fluxo do CI)
+
+1. Crie a tag no formato `vX.Y.Z` (ex.: `v1.1.5`) no commit desejado
+2. Dispare o workflow **build-gui** (manual, `workflow_dispatch`) informando a tag
+3. O CI roda `npm run publish:win|linux|mac` — o `electron-builder --publish always`
+   gera e publica na release:
+   - `GoLiveBypass.exe` + `latest.yml` (Windows)
+   - `GoLiveBypass.AppImage` + `latest-linux.yml` (Linux)
+   - `GoLiveBypass.dmg` + `GoLiveBypass.zip` + `latest-mac.yml` (macOS)
+
+> O `latest*.yml` é o metadata com checksum SHA-512 e o blockMap. **Sem ele na
+> release, o app detecta a versão nova mas não consegue baixar** (erro 404).
+
+## Assinatura (macOS — obrigatória; Windows — opcional)
+
+O auto-update do macOS só funciona com o app **assinado e notarizado**. O
+mantenedor precisa gerar os certificados e configurar os secrets do repositório
+(Settings → Secrets and variables → Actions):
+
+| Secret | O que é | Obrigatório para |
+|--------|---------|------------------|
+| `CSC_LINK` | Certificado de desenvolvedor da Apple (base64 do `.p12`) | macOS (e Windows, se quiser assinar) |
+| `CSC_KEY_PASSWORD` | Senha do certificado | macOS / Windows |
+| `APPLE_ID` | Apple ID do desenvolvedor | Notarização do macOS |
+| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password do Apple ID | Notarização do macOS |
+| `APPLE_TEAM_ID` | Team ID do desenvolvedor | Notarização do macOS |
+
+Para macOS:
+1. Gere o certificado "Developer ID Application" no Apple Developer portal
+2. Exporte como `.p12` e codifique em base64: `base64 -i cert.p12`
+3. Configure `CSC_LINK` com o base64, `CSC_KEY_PASSWORD` com a senha
+4. Gere um app-specific password em appleid.apple.com e configure
+   `APPLE_APP_SPECIFIC_PASSWORD` (+ `APPLE_ID` e `APPLE_TEAM_ID`)
+
+Sem os secrets, o CI builda sem assinatura e o auto-update do macOS fica
+desabilitado (o app funciona, mas não atualiza sozinho).
+
+> No Windows o portable **não exige assinatura** (o updater próprio substitui o
+> exe sem checagem de assinatura). Se quiser evitar o SmartScreen, assine com um
+> certificado de código (pode usar o mesmo `CSC_LINK` do Mac).
+
+## Notificação ao usuário
+
+O fluxo de atualização avisa antes de instalar:
+
+- **Mac/Linux**: o download corre em background; ao terminar, aparece um diálogo
+  *"GoLiveBypass X.Y.Z foi baixada — Reiniciar agora?"* — só instala com o OK
+- **Windows portable**: ao detectar a versão nova, pergunta *"Atualizar agora?"*
+  antes de baixar/substituir
+
+## Teste E2E (procedimento validado)
+
+### Linux (AppImage) — fluxo completo
+
+```bash
+# 1. Build da versão "nova" apontando para o fork de teste
+cd golive-gui
+sed -i 's/"owner": "bezumiya"/"owner": "SEU_FORK"/' package.json
+sed -i 's/"version": "1.0.0"/"version": "1.1.5"/' package.json
+npm run build:linux
+
+# 2. Publica a release de teste no fork (AppImage + latest-linux.yml)
+gh release create v1.1.5-test --repo SEU_FORK/GoLiveBypass \
+  dist-app/GoLiveBypass.AppImage dist-app/latest-linux.yml
+
+# 3. Build da versão "antiga" (1.0.0) e extrai para rodar sem o AppImageLauncher
+sed -i 's/"version": "1.1.5"/"version": "1.0.0"/' package.json
+npm run build:linux
+./dist-app/GoLiveBypass.AppImage --appimage-extract   # gera squashfs-root/
+
+# 4. Roda a antiga com APPIMAGE apontando para o arquivo a substituir
+APPIMAGE=$PWD/dist-app/GoLiveBypass.AppImage \
+  ./squashfs-root/golive-gui --no-sandbox
+```
+
+**Resultado esperado no log**: `Checking for update` → `Found version 1.1.5` →
+`New version 1.1.5 has been downloaded` → o arquivo `GoLiveBypass.AppImage` é
+substituído (tamanho muda) → reexecuta.
+
+> ⚠️ O AppImageLauncher (binfmt) intercepta AppImages e quebra o teste. A
+> extração com `--appimage-extract` + env `APPIMAGE` contorna isso.
+
+### Windows (portable) — procedimento
+
+```bash
+# 1. Build da versão "nova" no fork
+sed -i 's/"owner": "bezumiya"/"owner": "SEU_FORK"/' package.json
+sed -i 's/"version": "1.0.0"/"version": "1.1.5"/' package.json
+npm run build:win          # ou publish:win com GH_TOKEN
+
+# 2. Publica a release com GoLiveBypass.exe (+ latest.yml)
+gh release create v1.1.5-test --repo SEU_FORK/GoLiveBypass \
+  dist-app/GoLiveBypass.exe dist-app/latest.yml
+
+# 3. Roda o exe antigo (1.0.0); ele detecta a 1.1.5, pergunta "Atualizar agora?",
+#    baixa, substitui o exe em uso (com retry) e reabre a versão nova
+```
+
+**Pontos de atenção no Windows**:
+- O updater usa `PORTABLE_EXECUTABLE_FILE` (variável do electron-builder
+  portable) para achar o exe em uso — sem ela o update é pulado
+- A substituição tem retry (até 10 tentativas, 1s entre elas) porque o Windows
+  segura o exe em uso por um instante após o fechamento
+- Teste também o fluxo "Depois": o app continua rodando e a checagem periódica
+  (a cada 4h) oferece de novo
+
+### macOS — procedimento
+
+```bash
+# Com os secrets de assinatura configurados:
+npm run publish:mac          # gera dmg/zip assinados + latest-mac.yml
+
+# Roda o app antigo (1.0.0) num Mac; o autoUpdater detecta, baixa em background,
+# mostra "Reiniciar agora?" e aplica no quit (Squirrel.Mac aplica no relaunch)
+```
+
+**Validações no macOS**:
+- `codesign -dv --verbose=2 GoLiveBypass.app` deve mostrar `Developer ID Application`
+- `spctl -a -vv GoLiveBypass.dmg` deve passar (notarização ok)
+- O `latest-mac.yml` precisa estar na release junto do dmg/zip
+
+## Solução de problemas
+
+| Sintoma | Causa provável |
+|---------|----------------|
+| `Cannot find latest-linux.yml ... 404` | Release sem o metadata (CI antigo ou upload manual) — publique com `--publish always` |
+| `APPIMAGE env is not defined` | App rodando fora do runtime AppImage (teste extraído) — rode o AppImage normal ou set `APPIMAGE` |
+| `Update for version X is not available` | A release tem a **mesma versão** do app rodando — suba a versão no package.json |
+| macOS: download falha/instalação falha | App sem assinatura — configure `CSC_LINK`/`CSC_KEY_PASSWORD`/`APPLE_*` |
+| `downgrade is disallowed` | A release é mais antiga que a versão local — publique uma versão maior |

--- a/golive-gui/UPDATER.md
+++ b/golive-gui/UPDATER.md
@@ -144,6 +144,46 @@ npm run publish:mac          # gera dmg/zip assinados + latest-mac.yml
 - `spctl -a -vv GoLiveBypass.dmg` deve passar (notarização ok)
 - O `latest-mac.yml` precisa estar na release junto do dmg/zip
 
+## Testes por distro Linux
+
+O AppImage roda em qualquer distro, mas o comportamento do auto-update varia
+com o ambiente. Validar em pelo menos uma de cada grupo:
+
+### Grupo A — sem AppImageLauncher (mais comum: Ubuntu, Fedora, Arch puros)
+
+O fluxo padrão do electron-updater funciona sem ajustes: o AppImage é
+substituído in-place e reexecutado.
+
+```bash
+# 1. Publica a release de teste (v1.1.5) no fork (ver seção anterior)
+# 2. Copia o AppImage antigo (v1.0.0) para um diretório e roda
+mkdir -p ~/teste-update && cp dist-app/GoLiveBypass-1.0.0.AppImage ~/teste-update/
+chmod +x ~/teste-update/GoLiveBypass-1.0.0.AppImage
+~/teste-update/GoLiveBypass-1.0.0.AppImage
+# 3. Confirma: detecta -> baixa -> dialogo -> antigo morre -> novo abre
+#    (o arquivo em ~/teste-update agora tem o tamanho/versao da 1.1.5)
+```
+
+### Grupo B — com AppImageLauncher (KDE neon, Kubuntu, alguns Arch)
+
+O launcher intercepta AppImages e os renomeia com hash ao integrar
+(`GoLiveBypass-1.1.5_<hash>.AppImage`). O fluxo funciona, mas:
+
+- O arquivo atualizado aparece com nome `GoLiveBypass-1.1.5_<hash>` em
+  `~/Applications/` — **não** sobrescreve o antigo
+- O app antigo deve **morrer** (o `markQuittingForUpdate` garante) e o novo
+  abre integrado
+
+**Teste**: rodar o AppImage antigo de `~/Applications/` (integrado), atualizar,
+e conferir que o processo antigo sumiu (`pgrep -af golive-gui`) e o novo subiu.
+
+### Grupo C — sandbox/flatpak ou AppImage lido de mount temporário
+
+Se o AppImage for montado de um path temporário (ex.: teste extraído com
+`--appimage-extract`), o `APPIMAGE` env aponta para um arquivo que o updater
+não consegue substituir de forma estável. **Não é um cenário de produção** —
+use o AppImage inteiro (grupo A/B).
+
 ## Solução de problemas
 
 | Sintoma | Causa provável |
@@ -153,3 +193,5 @@ npm run publish:mac          # gera dmg/zip assinados + latest-mac.yml
 | `Update for version X is not available` | A release tem a **mesma versão** do app rodando — suba a versão no package.json |
 | macOS: download falha/instalação falha | App sem assinatura — configure `CSC_LINK`/`CSC_KEY_PASSWORD`/`APPLE_*` |
 | `downgrade is disallowed` | A release é mais antiga que a versão local — publique uma versão maior |
+| App fecha mas não abre após atualizar | App antigo segurando o lock de instância única — o `before-quit` não deve adiar o quit durante o update (o `markQuittingForUpdate` cuida disso; confira se o build tem esse fix) |
+| AppImageLauncher renomeia o arquivo com hash | Esperado: o nome versionado (`GoLiveBypass-1.1.5_<hash>`) evita sobrescrever o antigo; o app novo abre integrado |

--- a/golive-gui/dev-app-update.yml
+++ b/golive-gui/dev-app-update.yml
@@ -1,0 +1,8 @@
+# Configuracao de update para desenvolvimento (npm run dev).
+# O electron-updater le este arquivo quando forceDevUpdateConfig = true.
+# Aponta para o fork de teste; em producao quem vale e o app-update.yml gerado
+# no build (owner bezumiya).
+owner: pdl-clay
+repo: GoLiveBypass
+provider: github
+releaseType: release

--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -15,6 +15,7 @@ import fs from "fs";
 import { execFileSync, execSync, spawn, spawnSync } from "child_process";
 import { bypassCode } from "./bypass";
 import { runScript } from "./linux-helper";
+import { setupUpdater } from "./updater";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -424,6 +425,9 @@ if (!gotLock) {
     // evita o Tray cair para o GtkStatusIcon, que o Plasma 6 nao exibe.
     waitForStatusNotifier().then(createTray);
     app.on("activate", showWindow);
+    // Checa por atualizacao na release do GitHub (Windows portable: baixa e substitui;
+    // Mac/Linux: autoUpdater nativo). Roda sozinho e em silencio se nao houver nada.
+    setupUpdater(() => mainWindow);
   });
 }
 

--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -15,7 +15,7 @@ import fs from "fs";
 import { execFileSync, execSync, spawn, spawnSync } from "child_process";
 import { bypassCode } from "./bypass";
 import { runScript } from "./linux-helper";
-import { setupUpdater } from "./updater";
+import { setupUpdater, isQuittingForUpdate } from "./updater";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -438,6 +438,10 @@ if (!gotLock) {
 // Cmd+Q no Mac nao passa por window-all-closed da mesma forma que o Sair da bandeja no Windows:
 // o restore vive aqui para os dois caminhos.
 app.on("before-quit", (event) => {
+  // Durante o auto-update o quit nao pode ser adiado: o processo novo ja foi
+  // executado e precisa do lock de instancia unica. Sem esta saida, o app
+  // antigo fica vivo e o novo morre — o "fecha mas nao abre".
+  if (isQuittingForUpdate()) return;
   // A segunda instancia so acorda a primeira e morre: sem esta guarda ela restauraria o
   // Discord na saida, desfazendo o bypass que a instancia principal acabou de aplicar.
   if (!gotLock || cleaningUp) return;

--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -262,7 +262,11 @@ function refreshWindowStatus() {
 }
 
 function showWindow() {
-  if (mainWindow) {
+  // Durante o encerramento (quit, auto-update reexecutando) nao faz sentido
+  // mostrar janela: o mainWindow/tray podem ja estar destruidos, e acessar
+  // objetos destruidos derruba o app com "Object has been destroyed".
+  if (quitting) return;
+  if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.show();
     mainWindow.focus();
     // A bandeja pode ter mudado o startup ou o status com a janela escondida; ao reaparecer, sincroniza.

--- a/golive-gui/electron/updater.ts
+++ b/golive-gui/electron/updater.ts
@@ -146,10 +146,27 @@ export function setupUpdater(getMainWindow: () => BrowserWindow | null) {
   if (process.platform !== "win32") {
     autoUpdater.autoDownload = true;
     autoUpdater.logger = console;
-    autoUpdater.on("update-downloaded", () => {
+
+    // O download corre sozinho em background; ao terminar, avisa o usuario e
+    // so instala com o OK dele — atualizar sem avisar derruba o app na hora.
+    autoUpdater.on("update-downloaded", (info) => {
       updateReady = true;
-      autoUpdater.quitAndInstall();
+      const win = getMainWindow();
+      const choice = win
+        ? dialog.showMessageBoxSync(win, {
+            type: "info",
+            title: "Atualização disponível",
+            message: `GoLiveBypass ${info.version} foi baixada.`,
+            detail: "Reiniciar agora para aplicar a atualização? O app fecha e reabre sozinho.",
+            buttons: ["Reiniciar agora", "Depois"],
+            defaultId: 0,
+            cancelId: 1,
+          })
+        : 0;
+
+      if (choice === 0) autoUpdater.quitAndInstall();
     });
+
     autoUpdater.checkForUpdatesAndNotify().catch(() => {});
     return;
   }

--- a/golive-gui/electron/updater.ts
+++ b/golive-gui/electron/updater.ts
@@ -142,6 +142,17 @@ async function updateWindowsPortable(url: string): Promise<boolean> {
 // ------------------------------------------------------------------ API publica
 
 export function setupUpdater(getMainWindow: () => BrowserWindow | null) {
+  // Dev (npm run dev): o app roda fora do pacote, sem o app-update.yml embutido.
+  // O electron-updater usa o dev-app-update.yml na raiz do projeto + esta flag.
+  if (!app.isPackaged) {
+    autoUpdater.forceDevUpdateConfig = true;
+    // Em dev nao existe o runtime AppImage; sem este env o AppImageUpdater aborta
+    // antes de baixar. Aponta para um AppImage buildado (so o caminho importa aqui).
+    if (process.env.APPIMAGE === undefined) {
+      process.env.APPIMAGE = join(app.getAppPath(), "dist-app", "GoLiveBypass.AppImage");
+    }
+  }
+
   // Mac/Linux: updater nativo (dmg/zip assinado, AppImage).
   if (process.platform !== "win32") {
     autoUpdater.autoDownload = true;

--- a/golive-gui/electron/updater.ts
+++ b/golive-gui/electron/updater.ts
@@ -8,7 +8,8 @@
 // Mac e Linux: o autoUpdater do electron-updater cuida (dmg/zip assinado e AppImage).
 
 import { app, dialog, BrowserWindow } from "electron";
-import { createWriteStream } from "fs";
+import { createWriteStream, readFileSync } from "fs";
+import { createHash } from "crypto";
 import { rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -30,7 +31,7 @@ let updateReady = false;
 
 // ------------------------------------------------------------------ GitHub API
 
-function githubLatestRelease(): Promise<{ tag: string; url: string } | null> {
+function githubLatestRelease(): Promise<{ tag: string; url: string; digest: string | null } | null> {
   return new Promise((resolve) => {
     const req = request(
       {
@@ -58,7 +59,11 @@ function githubLatestRelease(): Promise<{ tag: string; url: string } | null> {
                 a.name.startsWith(EXE_PREFIX) && a.name.endsWith(".exe"),
             );
             if (!asset || !asset.browser_download_url) return resolve(null);
-            resolve({ tag: String(data.tag_name), url: asset.browser_download_url });
+            resolve({
+              tag: String(data.tag_name),
+              url: asset.browser_download_url,
+              digest: typeof asset.digest === "string" ? asset.digest : null,
+            });
           } catch {
             resolve(null);
           }
@@ -71,13 +76,33 @@ function githubLatestRelease(): Promise<{ tag: string; url: string } | null> {
   });
 }
 
-function downloadFile(url: string, dest: string): Promise<void> {
+// O browser_download_url do GitHub sempre responde 302 para release-assets.githubusercontent.com,
+// e o request do Node nao segue redirecionamento sozinho. Sem isto o download do Windows falhava
+// em toda tentativa: o app achava a versao nova e nunca conseguia baixar.
+const MAX_REDIRECTS = 5;
+
+function downloadFile(url: string, dest: string, hops = MAX_REDIRECTS): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = request(url, (res) => {
-      if (res.statusCode !== 200) {
+    // So https: um redirecionamento para http rebaixaria a conexao em silencio, e o que vem por
+    // ela substitui o executavel em uso.
+    if (!url.startsWith("https://")) {
+      return reject(new Error("recusando destino que nao e https: " + url));
+    }
+
+    const req = request(url, { headers: { "User-Agent": "GoLiveBypass" } }, (res) => {
+      const { statusCode, headers } = res;
+
+      if (statusCode !== undefined && statusCode >= 300 && statusCode < 400 && headers.location) {
         res.resume();
-        return reject(new Error("download falhou: HTTP " + res.statusCode));
+        if (hops <= 0) return reject(new Error("redirecionamentos demais"));
+        return downloadFile(new URL(headers.location, url).toString(), dest, hops - 1).then(resolve, reject);
       }
+
+      if (statusCode !== 200) {
+        res.resume();
+        return reject(new Error("download falhou: HTTP " + statusCode));
+      }
+
       const out = createWriteStream(dest);
       res.pipe(out);
       out.on("finish", () => {
@@ -89,6 +114,31 @@ function downloadFile(url: string, dest: string): Promise<void> {
     req.on("error", reject);
     req.end();
   });
+}
+
+// A API do GitHub devolve o digest do anexo na mesma resposta autenticada por TLS de onde sai a
+// URL. Conferir aqui deixa o Windows no mesmo nivel de Linux e macOS, que ganham a checagem de
+// graca pelo electron-updater. Sem isto, um arquivo truncado no meio do caminho viraria o
+// executavel em uso.
+function digestMatches(file: string, digest: string | null): boolean {
+  if (digest === null) {
+    console.warn("[updater] anexo sem digest na API; nao vou instalar sem conferir.");
+    return false;
+  }
+
+  const [algo, esperado] = digest.split(":");
+  if (algo === undefined || esperado === undefined) return false;
+
+  try {
+    const obtido = createHash(algo).update(readFileSync(file)).digest("hex");
+    if (obtido === esperado) return true;
+
+    console.error(`[updater] ${algo} nao confere: esperado ${esperado}, obtido ${obtido}`);
+    return false;
+  } catch (error) {
+    console.error("[updater] falhei ao conferir o digest:", error);
+    return false;
+  }
 }
 
 // ------------------------------------------------------------------ Windows portable
@@ -116,7 +166,7 @@ function tryReplace(target: string, downloaded: string): Promise<boolean> {
   });
 }
 
-async function updateWindowsPortable(url: string): Promise<boolean> {
+async function updateWindowsPortable(url: string, digest: string | null): Promise<boolean> {
   const current = portableExePath();
   if (current === null) {
     console.warn("[updater] PORTABLE_EXECUTABLE_FILE nao definido; pulando update.");
@@ -128,6 +178,13 @@ async function updateWindowsPortable(url: string): Promise<boolean> {
     await downloadFile(url, downloaded);
   } catch (error) {
     console.error("[updater] download falhou:", error);
+    return false;
+  }
+
+  // Conferido antes de encostar no exe em uso: depois do rename nao ha volta, o app se
+  // substituiu. Um arquivo que nao bate e apagado e a versao atual continua valendo.
+  if (!digestMatches(downloaded, digest)) {
+    await rm(downloaded, { force: true }).catch(() => {});
     return false;
   }
 
@@ -239,7 +296,7 @@ async function checkWindowsUpdate(getMainWindow: () => BrowserWindow | null) {
 
     if (choice !== 0) return;
 
-    const ok = await updateWindowsPortable(release.url);
+    const ok = await updateWindowsPortable(release.url, release.digest);
     if (ok) {
       updateReady = true;
       app.quit();

--- a/golive-gui/electron/updater.ts
+++ b/golive-gui/electron/updater.ts
@@ -17,7 +17,9 @@ import { autoUpdater } from "electron-updater";
 import { request } from "https";
 
 const REPO = "bezumiya/GoLiveBypass";
-const EXE_NAME = "GoLiveBypass.exe";
+// O artifactName leva a versao (GoLiveBypass-1.1.5.exe): o AppImageLauncher e
+// outros integradores nao sobrescrevem o arquivo quando o nome muda por versao.
+const EXE_PREFIX = "GoLiveBypass-";
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // re-checa a cada 4h
 const RETRY_COUNT = 10; // o exe em uso no Windows recusa rename por um tempo
 const RETRY_DELAY_MS = 1000;
@@ -52,7 +54,8 @@ function githubLatestRelease(): Promise<{ tag: string; url: string } | null> {
           try {
             const data = JSON.parse(body);
             const asset = (data.assets || []).find(
-              (a: { name: string }) => a.name === EXE_NAME,
+              (a: { name: string }) =>
+                a.name.startsWith(EXE_PREFIX) && a.name.endsWith(".exe"),
             );
             if (!asset || !asset.browser_download_url) return resolve(null);
             resolve({ tag: String(data.tag_name), url: asset.browser_download_url });
@@ -139,17 +142,29 @@ async function updateWindowsPortable(url: string): Promise<boolean> {
   return true;
 }
 
+// O main process consulta esta flag no before-quit: quando o auto-update esta
+// aplicando, o quit nao pode ser segurado (senao o app antigo fica vivo e o
+// novo morre no lock de instancia unica — o "fecha mas nao abre").
+let quittingForUpdate = false;
+export function markQuittingForUpdate() {
+  quittingForUpdate = true;
+}
+export function isQuittingForUpdate() {
+  return quittingForUpdate;
+}
+
 // ------------------------------------------------------------------ API publica
 
 export function setupUpdater(getMainWindow: () => BrowserWindow | null) {
   // Dev (npm run dev): o app roda fora do pacote, sem o app-update.yml embutido.
   // O electron-updater usa o dev-app-update.yml na raiz do projeto + esta flag.
-  if (!app.isPackaged) {
+  const isDev = !app.isPackaged;
+  if (isDev) {
     autoUpdater.forceDevUpdateConfig = true;
     // Em dev nao existe o runtime AppImage; sem este env o AppImageUpdater aborta
     // antes de baixar. Aponta para um AppImage buildado (so o caminho importa aqui).
     if (process.env.APPIMAGE === undefined) {
-      process.env.APPIMAGE = join(app.getAppPath(), "dist-app", "GoLiveBypass.AppImage");
+      process.env.APPIMAGE = join(app.getAppPath(), "dist-app", `GoLiveBypass-${app.getVersion()}.AppImage`);
     }
   }
 
@@ -175,7 +190,14 @@ export function setupUpdater(getMainWindow: () => BrowserWindow | null) {
           })
         : 0;
 
-      if (choice === 0) autoUpdater.quitAndInstall();
+      // Em dev o quitAndInstall nao funciona: nao ha runtime AppImage montado,
+      // e o processo e gerenciado pelo vite — o arquivo ate e substituido, mas
+      // o app nao reinicia (e o arquivo some). O dev serve para verificar a
+      // notificacao; a instalacao real so vale no app empacotado.
+      if (choice === 0 && !isDev) {
+        markQuittingForUpdate();
+        autoUpdater.quitAndInstall();
+      }
     });
 
     autoUpdater.checkForUpdatesAndNotify().catch(() => {});

--- a/golive-gui/electron/updater.ts
+++ b/golive-gui/electron/updater.ts
@@ -1,0 +1,202 @@
+// Atualizacao automatica via GitHub Releases — sem servidor proprio.
+//
+// Windows: o target e portable, e o electron-updater nao suporta portable (so NSIS).
+// Entao o update do Windows e proprio: consulta a release mais recente na API do
+// GitHub, baixa o exe novo, substitui o atual (via PORTABLE_EXECUTABLE_FILE, a
+// variavel que o electron-builder portable define) e reabre a versao nova.
+//
+// Mac e Linux: o autoUpdater do electron-updater cuida (dmg/zip assinado e AppImage).
+
+import { app, dialog, BrowserWindow } from "electron";
+import { createWriteStream } from "fs";
+import { rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawn } from "child_process";
+import { autoUpdater } from "electron-updater";
+import { request } from "https";
+
+const REPO = "bezumiya/GoLiveBypass";
+const EXE_NAME = "GoLiveBypass.exe";
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // re-checa a cada 4h
+const RETRY_COUNT = 10; // o exe em uso no Windows recusa rename por um tempo
+const RETRY_DELAY_MS = 1000;
+
+let lastCheckAt = 0;
+let checking = false;
+let updateReady = false;
+
+// ------------------------------------------------------------------ GitHub API
+
+function githubLatestRelease(): Promise<{ tag: string; url: string } | null> {
+  return new Promise((resolve) => {
+    const req = request(
+      {
+        host: "api.github.com",
+        path: `/repos/${REPO}/releases/latest`,
+        method: "GET",
+        headers: { "User-Agent": "GoLiveBypass", Accept: "application/vnd.github+json" },
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          return resolve(null);
+        }
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (c) => {
+          body += c;
+          if (body.length > 1_000_000) req.destroy();
+        });
+        res.on("end", () => {
+          try {
+            const data = JSON.parse(body);
+            const asset = (data.assets || []).find(
+              (a: { name: string }) => a.name === EXE_NAME,
+            );
+            if (!asset || !asset.browser_download_url) return resolve(null);
+            resolve({ tag: String(data.tag_name), url: asset.browser_download_url });
+          } catch {
+            resolve(null);
+          }
+        });
+      },
+    );
+    req.on("error", () => resolve(null));
+    req.setTimeout(15_000, () => req.destroy());
+    req.end();
+  });
+}
+
+function downloadFile(url: string, dest: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = request(url, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        return reject(new Error("download falhou: HTTP " + res.statusCode));
+      }
+      const out = createWriteStream(dest);
+      res.pipe(out);
+      out.on("finish", () => {
+        out.close();
+        resolve();
+      });
+      out.on("error", reject);
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+// ------------------------------------------------------------------ Windows portable
+
+function portableExePath(): string | null {
+  // O electron-builder portable define esta variavel com o caminho do exe em uso.
+  const current = process.env.PORTABLE_EXECUTABLE_FILE;
+  return current && current.trim() !== "" ? current : null;
+}
+
+function tryReplace(target: string, downloaded: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const attempt = (tries: number) => {
+      const { rmSync, renameSync } = require("fs");
+      try {
+        rmSync(target, { force: true });
+        renameSync(downloaded, target);
+        resolve(true);
+      } catch {
+        if (tries <= 0) return resolve(false);
+        setTimeout(() => attempt(tries - 1), RETRY_DELAY_MS);
+      }
+    };
+    attempt(RETRY_COUNT);
+  });
+}
+
+async function updateWindowsPortable(url: string): Promise<boolean> {
+  const current = portableExePath();
+  if (current === null) {
+    console.warn("[updater] PORTABLE_EXECUTABLE_FILE nao definido; pulando update.");
+    return false;
+  }
+
+  const downloaded = join(tmpdir(), "GoLiveBypass-update.exe");
+  try {
+    await downloadFile(url, downloaded);
+  } catch (error) {
+    console.error("[updater] download falhou:", error);
+    return false;
+  }
+
+  if (!(await tryReplace(current, downloaded))) {
+    console.error("[updater] nao consegui substituir o exe em uso.");
+    return false;
+  }
+
+  // Abre a versao nova e encerra a atual. O quit nao reverte o bypass: o novo
+  // processo assume e o before-quit do processo antigo desfaria a injecao.
+  spawn(current, [], { detached: true, stdio: "ignore" }).unref();
+  return true;
+}
+
+// ------------------------------------------------------------------ API publica
+
+export function setupUpdater(getMainWindow: () => BrowserWindow | null) {
+  // Mac/Linux: updater nativo (dmg/zip assinado, AppImage).
+  if (process.platform !== "win32") {
+    autoUpdater.autoDownload = true;
+    autoUpdater.logger = console;
+    autoUpdater.on("update-downloaded", () => {
+      updateReady = true;
+      autoUpdater.quitAndInstall();
+    });
+    autoUpdater.checkForUpdatesAndNotify().catch(() => {});
+    return;
+  }
+
+  // Windows portable: checagem periodica em background.
+  setInterval(() => void checkWindowsUpdate(getMainWindow), CHECK_INTERVAL_MS);
+  void checkWindowsUpdate(getMainWindow);
+}
+
+async function checkWindowsUpdate(getMainWindow: () => BrowserWindow | null) {
+  if (checking || updateReady) return;
+  if (Date.now() - lastCheckAt < 60_000) return; // no minimo 1min entre checagens
+  checking = true;
+  lastCheckAt = Date.now();
+
+  try {
+    const release = await githubLatestRelease();
+    if (release === null) return;
+
+    const current = app.getVersion();
+    const latest = release.tag.replace(/^v/, "");
+    const isNewer = latest !== current;
+    if (!isNewer) return;
+
+    const win = getMainWindow();
+    const choice = win
+      ? dialog.showMessageBoxSync(win, {
+          type: "info",
+          title: "Atualização disponível",
+          message: `GoLiveBypass ${latest} está disponível.`,
+          detail: "Baixar e instalar agora? O app reabre sozinho ao terminar.",
+          buttons: ["Atualizar agora", "Depois"],
+          defaultId: 0,
+          cancelId: 1,
+        })
+      : 0;
+
+    if (choice !== 0) return;
+
+    const ok = await updateWindowsPortable(release.url);
+    if (ok) {
+      updateReady = true;
+      app.quit();
+    } else {
+      console.error("[updater] falha ao aplicar o update portable.");
+    }
+  } finally {
+    checking = false;
+  }
+}

--- a/golive-gui/package-lock.json
+++ b/golive-gui/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "golive-gui",
       "version": "1.0.0",
+      "dependencies": {
+        "electron-updater": "^6.8.9"
+      },
       "devDependencies": {
         "electron": "^43.4.1",
         "electron-builder": "^26.15.3",
@@ -1099,7 +1102,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/asn1js": {
@@ -1255,7 +1257,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -1521,7 +1522,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1841,6 +1841,34 @@
         "mime": "^2.5.2"
       }
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -2136,7 +2164,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2377,7 +2404,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -2599,7 +2625,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2657,7 +2682,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -2680,7 +2704,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -2981,6 +3004,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -3173,7 +3209,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3851,7 +3886,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
       "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -4124,6 +4158,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4235,7 +4275,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/golive-gui/package.json
+++ b/golive-gui/package.json
@@ -7,17 +7,30 @@
   "scripts": {
     "dev": "vite",
     "compile": "node scripts/sync-bypass.mjs && tsc && vite build",
-    "build": "npm run compile && electron-builder",
-    "build:win": "npm run compile && electron-builder --win --x64",
-    "build:mac": "npm run compile && electron-builder --mac --arm64",
+    "build": "npm run compile && electron-builder --publish never",
+    "build:win": "npm run compile && electron-builder --win --x64 --publish never",
+    "build:mac": "npm run compile && electron-builder --mac --arm64 --publish never",
     "preview": "vite preview",
     "sync-bypass": "node scripts/sync-bypass.mjs",
-    "build:linux": "npm run compile && electron-builder --linux AppImage"
+    "build:linux": "npm run compile && electron-builder --linux AppImage --publish never",
+    "publish:win": "npm run compile && electron-builder --win --x64 --publish always",
+    "publish:mac": "npm run compile && electron-builder --mac --arm64 --publish always",
+    "publish:linux": "npm run compile && electron-builder --linux AppImage --publish always"
   },
   "build": {
     "appId": "com.golivebypass.gui",
     "productName": "GoLiveBypass",
-    "files": ["dist", "dist-electron", "assets"],
+    "publish": {
+      "provider": "github",
+      "owner": "bezumiya",
+      "repo": "GoLiveBypass",
+      "releaseType": "release"
+    },
+    "files": [
+      "dist",
+      "dist-electron",
+      "assets"
+    ],
     "directories": {
       "output": "dist-app"
     },
@@ -42,11 +55,15 @@
       "target": [
         {
           "target": "dmg",
-          "arch": ["arm64"]
+          "arch": [
+            "arm64"
+          ]
         },
         {
           "target": "zip",
-          "arch": ["arm64"]
+          "arch": [
+            "arm64"
+          ]
         }
       ],
       "icon": "build/icon.png",
@@ -60,7 +77,9 @@
       "artifactName": "${productName}.${ext}"
     },
     "linux": {
-      "target": ["AppImage"],
+      "target": [
+        "AppImage"
+      ],
       "category": "Utility",
       "icon": "build/icon.png",
       "artifactName": "${productName}.AppImage"
@@ -73,5 +92,8 @@
     "vite": "^8.2.0",
     "vite-plugin-electron": "^1.1.1",
     "vite-plugin-electron-renderer": "^1.0.0"
+  },
+  "dependencies": {
+    "electron-updater": "^6.8.9"
   }
 }

--- a/golive-gui/package.json
+++ b/golive-gui/package.json
@@ -39,7 +39,7 @@
       "icon": "build/icon.ico"
     },
     "portable": {
-      "artifactName": "${productName}.${ext}"
+      "artifactName": "${productName}-${version}.${ext}"
     },
     "extraResources": [
       {
@@ -82,7 +82,7 @@
       ],
       "category": "Utility",
       "icon": "build/icon.png",
-      "artifactName": "${productName}.AppImage"
+      "artifactName": "${productName}-${version}.${ext}"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## Resumo

Auto-update do GoLiveBypass consultando as **próprias releases do GitHub** (`api.github.com`), sem servidor intermediário. O app detecta a versão nova, baixa (com download diferencial), **avisa o usuário** e instala — reiniciando sozinho.

## Como funciona por SO

| SO | Mecanismo | Assinatura |
|----|-----------|------------|
| **Windows** | Updater próprio: consulta a release, baixa `GoLiveBypass-<versão>.exe`, substitui via `PORTABLE_EXECUTABLE_FILE` (com retry) e reabre | Não precisa |
| **Linux** | `AppImageUpdater` nativo com download diferencial (blockMap) | Não precisa |
| **macOS** | `MacUpdater` nativo (dmg/zip) | **Obrigatória** |

## Configuração do mantenedor (upstream original)

### 1. Secrets do repositório (Settings → Secrets and variables → Actions)

| Secret | O que é | Necessário para |
|--------|---------|-----------------|
| `CSC_LINK` | Certificado Developer ID da Apple (base64 do `.p12`) | macOS (e Windows opcional) |
| `CSC_KEY_PASSWORD` | Senha do certificado | macOS / Windows |
| `APPLE_ID` | Apple ID do desenvolvedor | Notarização macOS |
| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password | Notarização macOS |
| `APPLE_TEAM_ID` | Team ID | Notarização macOS |

**Gerar a assinatura macOS** (feita pelo mantenedor):
1. Apple Developer portal → certificado "Developer ID Application"
2. Exportar como `.p12` → `base64 -i cert.p12` → colar em `CSC_LINK`
3. `CSC_KEY_PASSWORD` = senha do `.p12`
4. `appleid.apple.com` → app-specific password → `APPLE_APP_SPECIFIC_PASSWORD`

Sem os secrets, o CI builda sem assinatura: Windows/Linux atualizam normalmente; **macOS não atualiza** (o app funciona, mas o download falha).

### 2. Publicar uma release

```bash
# Cria a tag vX.Y.Z e dispara o workflow build-gui (manual) com a tag
# O CI roda npm run publish:win|linux|mac -> electron-builder --publish always
# Publica na release: artefato + latest.yml / latest-linux.yml / latest-mac.yml
```

> O `latest*.yml` (metadata com SHA-512 + blockMap) é **obrigatório** na release — sem ele o app detecta a versão mas não baixa (404).

### 3. Notificação ao usuário

- **Mac/Linux**: download em background → diálogo *"GoLiveBypass X.Y.Z foi baixada — Reiniciar agora?"* → instala só com OK
- **Windows**: diálogo *"Atualizar agora?"* antes de baixar

## Como testar (procedimento E2E validado)

### Linux (testado em CachyOS com AppImageLauncher)

```bash
# 1. Fork de teste: build da "versão nova"
cd golive-gui
sed -i 's/"owner": "bezumiya"/"owner": "SEU_FORK"/' package.json
sed -i 's/"version": "1.0.0"/"version": "1.1.5"/' package.json
npm run build:linux

# 2. Publica a release de teste no fork
gh release create v1.1.5-test --repo SEU_FORK/GoLiveBypass \
  dist-app/GoLiveBypass-1.1.5.AppImage dist-app/latest-linux.yml

# 3. Build da "versão antiga" (1.0.0), roda e observa:
#    Checking for update -> Found version 1.1.5 -> baixa (diferencial ~200KB
#    de 125MB) -> diálogo -> app antigo MORRE -> app novo ABRE
```

**Validação**: `pgrep -af golive-gui` antes/depois; o AppImage antigo é substituído (ou integrado com hash pelo launcher).

### Por distro (ver `golive-gui/UPDATER.md`)

| Grupo | Distros | Comportamento |
|-------|---------|---------------|
| **A** — sem launcher | Ubuntu, Fedora, Arch puros | AppImage substituído in-place e reexecutado |
| **B** — com AppImageLauncher | KDE neon, Kubuntu | Arquivo novo com hash (`GoLiveBypass-1.1.5_<hash>`) em `~/Applications/`; antigo morre, novo abre |
| **C** — sandbox/mount temporário | Testes com `--appimage-extract` | Não é cenário de produção; usar AppImage inteiro |

### Windows

```bash
npm run build:win   # gera GoLiveBypass-1.1.5.exe + latest.yml
# Roda o exe antigo: detecta, pergunta, baixa, substitui (retry p/ arquivo em uso), reabre
```

### macOS

```bash
npm run publish:mac  # com os secrets de assinatura
# Valida: codesign -dv (Developer ID) e spctl -a -vv (notarização)
```

## Mudanças (5 commits)

- `gui: auto-update via GitHub Releases` — updater Windows portable + autoUpdater nativo + CI publish + publish config
- `gui: notificacao de atualizacao antes de instalar + guia do mantenedor` — diálogo de confirmação + `UPDATER.md`
- `gui: corrige crash no auto-update + suporte a teste em dev` — guarda `isDestroyed` no showWindow + `dev-app-update.yml`
- `gui: corrige "fecha mas nao abre" no auto-update do AppImage` — `markQuittingForUpdate` (before-quit não segura o quit) + artifactName versionado
- `docs: UPDATER.md com testes por distro Linux e novos casos de troubleshooting`

## Arquivos

```
golive-gui/electron/updater.ts     (novo)
golive-gui/electron/main.ts        (setupUpdater + before-quit fix)
golive-gui/package.json            (electron-updater + publish github + artifactName versionado)
golive-gui/dev-app-update.yml      (novo, teste em dev)
golive-gui/UPDATER.md              (novo, guia completo do mantenedor)
.github/workflows/build-gui.yml    (publish always + secrets)
```

## Testes realizados

- **E2E Linux completo** (CachyOS + AppImageLauncher): v1.0.0 → v1.1.5, download diferencial 266KB de 125MB, diálogo, antigo morre, novo abre (verificado pelo `refreshExit` no app.asar do mount novo)
- Typecheck e build passando