### PR TITLE
gui: campo de proxy customizada visivel apos reiniciar o app

### DIFF
--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -747,6 +747,10 @@ async function activateBypass(event: any, proxyAddress: string = "") {
   const installs = getDiscordInstalls();
   if (installs.length === 0) throw new Error("Nenhum Discord encontrado.");
 
+  // Salvo antes de mexer no Discord: mesmo que a injecao falhe, o que a pessoa digitou nao se
+  // perde, e o campo continua preenchido na proxima abertura.
+  saveProxy(proxyAddress);
+
   for (const install of installs) {
     assertDiscordSignature(install.bundlePath);
     assertResourcesWritable(install);
@@ -919,24 +923,55 @@ ipcMain.handle("set-startup", (_event, enabled: unknown) => {
   refreshTray().catch(() => {});
 });
 
-// A proxy salva fica no settings.json da pasta compartilhada do bypass
-// (a mesma que o standalone/golivebypass.js leem). Sem este handler a UI
-// nunca saberia que ha uma proxy configurada apos reiniciar o app.
+// A pasta compartilhada do bypass — a mesma que o standalone/golivebypass.js e os instaladores
+// usam. O XDG_DATA_HOME entra na conta porque o standalone e o plugin ja o respeitam: sem isso,
+// quem move essa pasta acabaria com duas configuracoes em lugares diferentes.
 function settingsDir() {
-  return process.platform === "win32"
-    ? path.join(process.env.LOCALAPPDATA || app.getPath("appData"), "GoLiveBypass")
-    : path.join(app.getPath("home"), ".local", "share", "GoLiveBypass");
+  if (process.platform === "win32") {
+    return path.join(process.env.LOCALAPPDATA || app.getPath("appData"), "GoLiveBypass");
+  }
+  const base = process.env.XDG_DATA_HOME || path.join(app.getPath("home"), ".local", "share");
+  return path.join(base, "GoLiveBypass");
 }
 
-ipcMain.handle("get-proxy", () => {
+function readProxyFrom(file: string) {
   try {
-    const file = path.join(settingsDir(), "settings.json");
     if (!fs.existsSync(file)) return "";
     const data = JSON.parse(fs.readFileSync(file, "utf8"));
     return typeof data.proxy === "string" ? data.proxy : "";
   } catch {
     return "";
   }
+}
+
+// Guardado fora da pasta do Discord de proposito: o settings.json que o bypass le vive dentro do
+// app.asar injetado, e esse some quando o bypass e desativado ou quando o Discord se atualiza.
+// A copia daqui e a configuracao da pessoa, e sobrevive aos dois.
+function saveProxy(proxy: string) {
+  try {
+    const dir = settingsDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, "settings.json");
+
+    const atual = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, "utf8")) : {};
+    fs.writeFileSync(file, JSON.stringify({ ...atual, proxy }, null, 4));
+  } catch (error) {
+    console.error("[settings] nao consegui salvar a proxy:", error);
+  }
+}
+
+ipcMain.handle("get-proxy", () => {
+  const salva = readProxyFrom(path.join(settingsDir(), "settings.json"));
+  if (salva !== "") return salva;
+
+  // Quem ativou antes desta versao so tem o settings.json dentro do app.asar injetado. Ler de
+  // la evita que a proxy configurada suma na atualizacao do app.
+  for (const install of getDiscordInstalls()) {
+    const doAsar = readProxyFrom(path.join(install.resources, "app.asar", "settings.json"));
+    if (doAsar !== "") return doAsar;
+  }
+
+  return "";
 });
 
 // A pagina reporta a altura de que precisa (o warning do bypass ativo faz o conteudo crescer).

--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -919,6 +919,26 @@ ipcMain.handle("set-startup", (_event, enabled: unknown) => {
   refreshTray().catch(() => {});
 });
 
+// A proxy salva fica no settings.json da pasta compartilhada do bypass
+// (a mesma que o standalone/golivebypass.js leem). Sem este handler a UI
+// nunca saberia que ha uma proxy configurada apos reiniciar o app.
+function settingsDir() {
+  return process.platform === "win32"
+    ? path.join(process.env.LOCALAPPDATA || app.getPath("appData"), "GoLiveBypass")
+    : path.join(app.getPath("home"), ".local", "share", "GoLiveBypass");
+}
+
+ipcMain.handle("get-proxy", () => {
+  try {
+    const file = path.join(settingsDir(), "settings.json");
+    if (!fs.existsSync(file)) return "";
+    const data = JSON.parse(fs.readFileSync(file, "utf8"));
+    return typeof data.proxy === "string" ? data.proxy : "";
+  } catch {
+    return "";
+  }
+});
+
 // A pagina reporta a altura de que precisa (o warning do bypass ativo faz o conteudo crescer).
 // A janela e fixa (resizable: false), entao o proprio app ajusta para caber tudo sem cortar.
 ipcMain.on('resize-window', (_event, height: unknown) => {

--- a/golive-gui/electron/preload.ts
+++ b/golive-gui/electron/preload.ts
@@ -5,6 +5,7 @@ import { ipcRenderer } from 'electron';
   activate: (proxy?: string) => ipcRenderer.invoke('activate', proxy),
   deactivate: () => ipcRenderer.invoke('deactivate'),
   getStatus: () => ipcRenderer.invoke('get-status'),
+  getProxy: () => ipcRenderer.invoke('get-proxy'),
   getPlatform: () => ipcRenderer.invoke('get-platform'),
   getStartup: () => ipcRenderer.invoke('get-startup'),
   setStartup: (enabled: boolean) => ipcRenderer.invoke('set-startup', enabled),

--- a/golive-gui/src/main.ts
+++ b/golive-gui/src/main.ts
@@ -7,6 +7,7 @@ declare global {
       activate: (proxy?: string) => Promise<void>;
       deactivate: () => Promise<void>;
       getStatus: () => Promise<string>;
+      getProxy: () => Promise<string>;
       getPlatform: () => Promise<string>;
       getStartup: () => Promise<boolean>;
       setStartup: (enabled: boolean) => Promise<void>;
@@ -202,11 +203,22 @@ applyPlatformCopy();
 initTheme();
 updateStatus();
 refreshStartup();
+refreshProxy();
 fitWindowToContent();
 
 async function refreshStartup() {
   try {
     startupToggle.checked = await window.api.getStartup();
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+// Preenche o campo de proxy com o valor salvo no settings.json (se houver),
+// para a configuracao ficar visivel apos reiniciar o app.
+async function refreshProxy() {
+  try {
+    proxyInput.value = await window.api.getProxy();
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
## Problema

Ao configurar uma proxy customizada e reiniciar o app (AppImage/exe), o campo
"Proxy Customizada" aparecia **vazio** — a UI nunca lia o settings.json de
volta, então o usuário não sabia que havia uma proxy configurada.

## Correção

- **`electron/main.ts`**: novo handler IPC `get-proxy` que lê o `settings.json`
  da pasta compartilhada do bypass (`~/.local/share/GoLiveBypass/` no Linux,
  `%LOCALAPPDATA%\GoLiveBypass\` no Windows)
- **`electron/preload.ts`**: expõe `getProxy()` para o renderer
- **`src/main.ts`**: `refreshProxy()` preenche o campo na inicialização

## Testes

- Typecheck e build passando
- Validado no AppImage: ao reiniciar com proxy salva, o campo mostra o valor
  configurado