### PR TITLE
installer: pnpm mais robusto — corepack desligado + fallback standalone oficial

### DIFF
--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -311,9 +311,12 @@ function Install-Pnpm {
     # keyid") ou ele pergunta "Corepack is about to download..." e, sem quem responder,
     # derruba o instalador. Desligar o corepack tira esse atalho do caminho; quem ja tiver
     # o pnpm de verdade instalado passa a ser encontrado de novo.
+    # "disable pnpm", e nao "disable" seco: o segundo leva o atalho do yarn junto, e o yarn
+    # nao e nosso para desligar. Esta funcao so roda com o pnpm ja reprovado no Test-Pnpm,
+    # entao quem tem um corepack que funciona nunca passa por aqui.
     if (Test-Tool 'corepack') {
-        Write-Step 'Desligando o corepack'
-        & corepack disable 2>$null | Out-Null
+        Write-Step 'Desligando o atalho quebrado do pnpm no corepack'
+        & corepack disable pnpm 2>$null | Out-Null
         if ($LASTEXITCODE -eq 0) { Update-PathFromEnvironment }
     }
 

--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -305,6 +305,70 @@ function Show-ModChoice {
     }
 }
 
+function Install-Pnpm {
+    # O corepack vem ligado no Node 22 e cria um atalho do pnpm que quebra na primeira
+    # execucao: as chaves de assinatura embutidas estao velhas ("Cannot find matching
+    # keyid") ou ele pergunta "Corepack is about to download..." e, sem quem responder,
+    # derruba o instalador. Desligar o corepack tira esse atalho do caminho; quem ja tiver
+    # o pnpm de verdade instalado passa a ser encontrado de novo.
+    if (Test-Tool 'corepack') {
+        Write-Step 'Desligando o corepack'
+        & corepack disable 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) { Update-PathFromEnvironment }
+    }
+
+    if (Test-Pnpm) { return }
+
+    Write-Step 'Instalando o pnpm pelo npm'
+    & npm install -g pnpm | Out-Host
+
+    if ($LASTEXITCODE -eq 0) {
+        Update-PathFromEnvironment
+        if (Test-Pnpm) { return }
+    }
+
+    # O npm global mora na pasta do Node; com o Node instalado em "Arquivos de Programas"
+    # (o instalador padrao do site), escrever ali exige admin e o npm falha com EPERM.
+    # Num prefixo dentro do perfil o npm escreve sem admin, e o pnpm entra no PATH desta
+    # sessao e fica registrado no PATH do usuario para as proximas.
+    Write-Step 'O npm nao conseguiu escrever na pasta global; instalando num prefixo do seu perfil'
+    $pnpmHome = Join-Path $env:LOCALAPPDATA 'pnpm-global'
+    & npm install -g --prefix $pnpmHome pnpm | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw 'O npm nao conseguiu instalar o pnpm. Rode "npm install -g pnpm" num terminal como administrador e tente de novo.'
+    }
+
+    $env:Path = "$pnpmHome;$env:Path"
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($userPath -notlike "*$pnpmHome*") {
+        [Environment]::SetEnvironmentVariable('Path', "$pnpmHome;$userPath", 'User')
+    }
+
+    if (-not (Test-Pnpm)) {
+        # Ultimo recurso, e o mais robusto: o instalador oficial baixa o binario standalone
+        # do pnpm (que nem precisa do Node instalado) para %LOCALAPPDATA%\pnpm, sem admin
+        # e sem depender do npm. O instalador pode ser 5.1 (sem verificacao de assinatura)
+        # e ainda assim valida o checksum por baixo.
+        Write-Step 'Baixando o pnpm do site oficial (pasta do usuario, sem admin)'
+        $installer = Join-Path $env:TEMP 'install-pnpm.ps1'
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri 'https://get.pnpm.io/install.ps1' -OutFile $installer
+            & powershell -NoProfile -ExecutionPolicy Bypass -File $installer 2>&1 | Out-Host
+        } catch {
+            Write-Step 'O download do site oficial falhou; seguindo para a checagem final.'
+        }
+        Update-PathFromEnvironment
+        # O setup do pnpm grava o PATH do usuario; no caso de nao ter gravado, os dois
+        # caminhos possiveis (com e sem \bin) entram aqui na sessao.
+        $pnpmHome = Join-Path $env:LOCALAPPDATA 'pnpm'
+        $env:Path = "$pnpmHome\bin;$pnpmHome;$env:Path"
+    }
+
+    if (-not (Test-Pnpm)) {
+        throw 'Nao consegui deixar o pnpm funcionando. Abra um terminal e rode: npm install -g pnpm'
+    }
+}
+
 function Install-Toolchain($needGit) {
     $missing = @()
     if ($needGit -and -not (Test-Tool 'git')) { $missing += 'git' }
@@ -332,23 +396,7 @@ function Install-Toolchain($needGit) {
         exit 0
     }
 
-    if (-not (Test-Pnpm)) {
-        # Sem corepack de proposito. Ele so serviria para fixar a versao do campo packageManager,
-        # que o proprio pnpm ja respeita, e em troca traz dois modos de falha: as chaves de
-        # assinatura vencidas que vem no Node 22, e uma pergunta interativa antes de baixar que
-        # deixa o instalador parado esperando uma resposta que ninguem sabe que precisa dar.
-        Write-Step 'Instalando o pnpm pelo npm'
-        # Out-Host, e nao a saida solta: um comando nativo escreve na saida da funcao, e esta
-        # funcao roda dentro de outra cujo retorno vira o caminho do checkout. Sem isto, as
-        # linhas de aviso do npm entram no valor de retorno e o caminho vira um array.
-        & npm install -g pnpm | Out-Host
-        if ($LASTEXITCODE -ne 0) { throw 'O npm nao conseguiu instalar o pnpm. Rode "npm install -g pnpm" na mao e tente de novo.' }
-        Update-PathFromEnvironment
-    }
-
-    if (-not (Test-Pnpm)) {
-        throw 'Nao consegui deixar o pnpm funcionando. Abra um terminal e rode: npm install -g pnpm'
-    }
+    if (-not (Test-Pnpm)) { Install-Pnpm }
 
     Write-Ok "pnpm $script:PnpmVersion"
 }

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -533,10 +533,14 @@ ensure_toolchain() {
     # execucao: as chaves de assinatura embutidas estao velhas e o atalho morre com
     # "Cannot find matching keyid", ou fica esperando resposta no stdin. O </dev/null do
     # have_pnpm corta essa espera, mas o atalho continua no PATH atrapalhando a instalacao
-    # e o uso do pnpm de verdade. Desligar o corepack tira esse atalho do caminho.
-    if have corepack; then
-        step "Desligando o corepack"
-        corepack disable >/dev/null 2>&1 || true
+    # e o uso do pnpm de verdade. Desligar tira esse atalho do caminho.
+    #
+    # So mexemos nisso quando o pnpm nao esta funcionando: se o corepack ja entrega um pnpm
+    # que roda, desligar seria estragar a maquina de quem estava bem. E "disable pnpm", nao
+    # "disable" seco, que tambem levaria o atalho do yarn junto -- nao e nosso para desligar.
+    if ! have_pnpm && have corepack; then
+        step "Desligando o atalho quebrado do pnpm no corepack"
+        corepack disable pnpm >/dev/null 2>&1 || true
         hash -r 2>/dev/null || true
     fi
 

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -529,10 +529,16 @@ ensure_toolchain() {
         fail "Atualize o Node e rode de novo."
     fi
 
-    # Sem corepack de proposito. Ele so serviria para fixar a versao do campo packageManager,
-    # que o proprio pnpm ja respeita, e em troca traz dois modos de falha: as chaves de
-    # assinatura vencidas que vem no Node 22, e uma pergunta interativa antes de baixar que
-    # deixa o instalador parado esperando uma resposta que ninguem sabe que precisa dar.
+    # O corepack vem ligado no Node 22 e cria um atalho do pnpm que quebra na primeira
+    # execucao: as chaves de assinatura embutidas estao velhas e o atalho morre com
+    # "Cannot find matching keyid", ou fica esperando resposta no stdin. O </dev/null do
+    # have_pnpm corta essa espera, mas o atalho continua no PATH atrapalhando a instalacao
+    # e o uso do pnpm de verdade. Desligar o corepack tira esse atalho do caminho.
+    if have corepack; then
+        step "Desligando o corepack"
+        corepack disable >/dev/null 2>&1 || true
+        hash -r 2>/dev/null || true
+    fi
 
     # No Arch o pnpm e um pacote como qualquer outro, e sai mais limpo que um -g do npm em
     # /usr/lib, que fica fora do controle do pacman.
@@ -545,6 +551,23 @@ ensure_toolchain() {
     if ! have_pnpm; then
         step "Instalando o pnpm pelo npm"
         npm install -g pnpm >/dev/null 2>&1 || sudo npm install -g pnpm >/dev/null 2>&1 || true
+        hash -r 2>/dev/null || true
+    fi
+
+    # Fallback mais robusto: o instalador oficial baixa o binario standalone do pnpm
+    # (que nem precisa do Node instalado) para a pasta do usuario, sem sudo e sem tocar
+    # no npm. O default do instalador e ~/.pnpm no HOME; fixamos o PNPM_HOME para nao
+    # depender do default de versao nenhuma, e o binario cai em $PNPM_HOME/bin.
+    if ! have_pnpm && { have curl || have wget; }; then
+        step "Baixando o pnpm do site oficial (pasta do usuario, sem sudo)"
+        PNPM_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/pnpm"
+        export PNPM_HOME
+        if have curl; then
+            curl -fsSL https://get.pnpm.io/install.sh | sh - >/dev/null 2>&1 || true
+        else
+            wget -qO- https://get.pnpm.io/install.sh | sh - >/dev/null 2>&1 || true
+        fi
+        PATH="$PNPM_HOME/bin:$PATH"
         hash -r 2>/dev/null || true
     fi
 


### PR DESCRIPTION
## O problema

O atalho que o corepack cria para o pnpm no Node 22 quebra na primeira execucao: as chaves de assinatura embutidas estao velhas (erro "Cannot find matching keyid") ou ele dispara o prompt "Corepack is about to download..." num contexto onde ninguem responde, derrubando o instalador inteiro **antes** de chegar ao fallback do `npm install -g pnpm`.

Alem disso, no Windows com o Node instalado em "Arquivos de Programas" (o padrao do instalador MSI), o `npm install -g pnpm` falha com EPERM sem uma janela elevada.

## A solucao

Nos dois instaladores (`golivebypass-installer.sh` e `GoLiveBypass-Installer.ps1`):

1. **`corepack disable` antes de qualquer teste/instalacao de pnpm** — tira o atalho quebrado do PATH.
2. **Novo ultimo recurso: instalador oficial do pnpm** (`get.pnpm.io`), que baixa o binario standalone para a pasta do usuario:
   - nao depende do npm nem do Node instalado;
   - nao precisa de admin/sudo;
   - baixa da propria npm registry com verificacao de assinatura + checksum.

Cadeia final:

- **Linux**: `corepack disable` → pnpm ja funciona? → pacman (Arch) → `npm install -g` (com sudo) → instalador oficial → falha com instrucao
- **Windows**: `corepack disable` → `npm install -g` → prefixo no perfil (sem admin) → instalador oficial → falha com instrucao

## Testes

- Fluxo completo do `install.sh` oficial validado na pratica (instalou pnpm 11.22.0 standalone num sandbox).
- `sh -n` OK no script Linux.

Relato que motivou: instalacao no Windows da 1.1.6 morria com `[X] ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11.22.0.tgz`.