### PR TITLE
fix: detectar Discord mesmo com pasta app-* incompleta durante update

### DIFF
--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -505,6 +505,29 @@ interface DiscordInstall {
   bundlePath?: string;
 }
 
+function winAppHasDiscordResources(resourcesPath: string): boolean {
+  const asar = path.join(resourcesPath, "app.asar");
+  const originalAsar = path.join(resourcesPath, "_app.asar");
+  return diskFs.existsSync(asar) || diskFs.existsSync(originalAsar);
+}
+
+// O Squirrel baixa updates numa pasta app-VERSAO nova antes de terminar; enquanto isso ela
+// pode existir sem app.asar/_app.asar. Pegar so a "mais nova" cega falha com NOT_FOUND.
+function findLatestValidWinAppDir(rootPath: string): string | null {
+  let dirs: string[];
+  try {
+    dirs = diskFs.readdirSync(rootPath).filter((d) => d.startsWith("app-"));
+  } catch {
+    return null;
+  }
+  dirs.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+  for (const dir of dirs) {
+    const resourcesPath = path.join(rootPath, dir, "resources");
+    if (winAppHasDiscordResources(resourcesPath)) return dir;
+  }
+  return null;
+}
+
 function getWinDiscordInstalls(): DiscordInstall[] {
   const localAppData = process.env.LOCALAPPDATA;
   if (!localAppData) return [];
@@ -514,20 +537,12 @@ function getWinDiscordInstalls(): DiscordInstall[] {
     const rootPath = path.join(localAppData, flavour);
     if (!diskFs.existsSync(rootPath)) continue;
 
-    const dirs = diskFs
-      .readdirSync(rootPath)
-      .filter((d) => d.startsWith("app-"));
-    if (dirs.length === 0) continue;
+    const latestApp = findLatestValidWinAppDir(rootPath);
+    if (!latestApp) continue;
 
-    dirs.sort();
-    const latestApp = dirs[dirs.length - 1];
     const resourcesPath = path.join(rootPath, latestApp, "resources");
     const exePath = path.join(rootPath, latestApp, `${flavour}.exe`);
-    const asar = path.join(resourcesPath, "app.asar");
-    const originalAsar = path.join(resourcesPath, "_app.asar");
-    if (diskFs.existsSync(asar) || diskFs.existsSync(originalAsar)) {
-      installs.push({ flavour, resources: resourcesPath, exePath });
-    }
+    installs.push({ flavour, resources: resourcesPath, exePath });
   }
   return installs;
 }

--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -138,6 +138,12 @@ function Test-ModCheckout($path) {
     return Test-Path -LiteralPath (Join-Path $path 'src\utils\types.ts')
 }
 
+function Test-DiscordResourcesReady($resources) {
+    $asar = Join-Path $resources 'app.asar'
+    $original = Join-Path $resources '_app.asar'
+    return (Test-Path -LiteralPath $asar) -or (Test-Path -LiteralPath $original)
+}
+
 function Get-DiscordResources {
     $found = @()
     foreach ($name in $DiscordNames) {
@@ -145,15 +151,17 @@ function Get-DiscordResources {
         if (-not (Test-Path -LiteralPath $root)) { continue }
 
         $apps = Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue |
-            Where-Object {
-                $_.Name -match '^app-[0-9]' -and
-                (Test-Path -LiteralPath (Join-Path $_.FullName 'resources'))
-            } |
+            Where-Object { $_.Name -match '^app-[0-9]' } |
             Sort-Object -Descending -Property @{ Expression = {
                 try { [version]($_.Name -replace '^app-', '') } catch { [version]'0.0.0' }
             } }
 
-        foreach ($app in $apps) { $found += (Join-Path $app.FullName 'resources') }
+        foreach ($app in $apps) {
+            $resources = Join-Path $app.FullName 'resources'
+            if (Test-DiscordResourcesReady $resources) {
+                $found += $resources
+            }
+        }
     }
     return $found
 }

--- a/standalone/GoLiveBypass-Standalone.ps1
+++ b/standalone/GoLiveBypass-Standalone.ps1
@@ -54,8 +54,14 @@ function Confirm-Action($question) {
     return $answer -match '^[sSyY]'
 }
 
-# Cada versao do Discord vive numa pasta app-VERSAO propria. A que importa e a mais nova, que
-# e a que o atalho abre.
+function Test-DiscordResourcesReady($resources) {
+    $asar = Join-Path $resources 'app.asar'
+    $original = Join-Path $resources '_app.asar'
+    return (Test-Path -LiteralPath $asar) -or (Test-Path -LiteralPath $original)
+}
+
+# Cada versao do Discord vive numa pasta app-VERSAO propria. A que importa e a mais nova
+# completa: durante um update o Squirrel cria a pasta nova antes de copiar app.asar.
 function Get-DiscordResources {
     $found = @()
     foreach ($flavour in $DiscordFlavours) {
@@ -63,11 +69,18 @@ function Get-DiscordResources {
         if (-not (Test-Path -LiteralPath $root)) { continue }
 
         $versions = Get-ChildItem -LiteralPath $root -Directory -Filter 'app-*' -ErrorAction SilentlyContinue |
-            Sort-Object { [Version]($_.Name -replace '^app-', '') } -ErrorAction SilentlyContinue
+            Sort-Object { [Version]($_.Name -replace '^app-', '') } -Descending -ErrorAction SilentlyContinue
         if (-not $versions) { continue }
 
-        $resources = Join-Path $versions[-1].FullName 'resources'
-        if (Test-Path -LiteralPath (Join-Path $resources 'app.asar')) {
+        $resources = $null
+        foreach ($ver in $versions) {
+            $candidate = Join-Path $ver.FullName 'resources'
+            if (Test-DiscordResourcesReady $candidate) {
+                $resources = $candidate
+                break
+            }
+        }
+        if ($resources) {
             $found += [pscustomobject]@{ Flavour = $flavour; Resources = $resources }
         }
     }


### PR DESCRIPTION
## Summary

Corrige o bug em que o GoLiveBypass reportava **"Discord não encontrado"** (`NOT_FOUND`) mesmo com o Discord instalado e funcionando.

### Causa raiz

O Discord no Windows usa o **Squirrel** para atualizar. Durante um update, o instalador cria uma pasta `app-<versão>` **nova** em `%LOCALAPPDATA%\Discord\` **antes** de copiar `app.asar` / `_app.asar` para dentro dela.

Exemplo real observado no ambiente de teste:

| Pasta | Estado |
|-------|--------|
| `app-1.0.9255` | Criada pelo update, **sem** `resources/app.asar` nem `_app.asar` |
| `app-1.0.9254` | Instalação **completa e válida** |

A detecção antiga pegava sempre a pasta `app-*` **mais recente** (ordenação lexicográfica / último item) e exigia que ela tivesse os arquivos asar. Se a mais nova estava incompleta, retornava `NOT_FOUND` — ignorando versões anteriores ainda utilizáveis.

### O que mudou

Em **todos os três pontos de detecção no Windows**, a lógica agora:

1. Lista as pastas `app-*` ordenadas da **mais nova para a mais antiga** (comparação numérica de versão)
2. Retorna a **primeira** cujo `resources/` contenha `app.asar` **ou** `_app.asar`
3. Ignora pastas incompletas criadas por updates pendentes

Arquivos alterados:

- `golive-gui/electron/main.ts` — GUI Electron (`getWinDiscordInstalls`, helpers `winAppHasDiscordResources` / `findLatestValidWinAppDir`)
- `standalone/GoLiveBypass-Standalone.ps1` — script standalone Windows
- `installer/GoLiveBypass-Installer.ps1` — instalador Equicord/Vencord

### Melhorias colaterais

- Ordenação de versão na GUI passa a usar `localeCompare` com `{ numeric: true }` em vez de sort lexicográfico simples (`app-1.0.100` vs `app-1.0.99`)
- Standalone e instalador agora também aceitam `_app.asar` como critério de pasta válida (antes o standalone exigia só `app.asar`)

## Test plan

- [x] Reproduzir o cenário: `%LOCALAPPDATA%\Discord\` com pasta `app-*` mais nova incompleta e uma anterior válida → detecção aponta para a versão válida
- [x] `GoLiveBypass-Standalone.ps1 -Mode Status` encontra o Discord corretamente
- [x] Build da GUI (`npm run build:win`) conclui sem erros
- [ ] Abrir a GUI compilada e confirmar que o status **não** é mais `NOT_FOUND`
- [ ] Cenário vanilla: apenas uma pasta `app-*` completa → comportamento inalterado
- [ ] Cenário pós-update: pasta nova completa substitui a antiga → passa a usar a mais nova válida
- [ ] Discord PTB / Canary com layout Squirrel padrão em `%LOCALAPPDATA%`
