### PR TITLE
feat(gui): modo dev com janela de logs, VPS testável e report de bug

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -4,7 +4,8 @@ API_TOKEN=gerar_um_segredo_compartilhado
 
 # Opcionais
 GITHUB_REPO=bezumiya/GoLiveBypass
-ISSUE_LABELS=bug
+# Labels precisam existir no repo. Crie "gui" uma vez (Settings → Labels).
+ISSUE_LABELS=bug,gui
 PORT=8080
 RATE_LIMIT=60
 MAX_LOG_BYTES=262144

--- a/api/README.md
+++ b/api/README.md
@@ -24,8 +24,8 @@ app (GUI/standalone, futuro)              API (este serviço)              GitHu
    Fine-grained personal access tokens*, com acesso somente ao repositório
    alvo (`Repository access → Only select repositories`) e permissão
    **Issues: write**.
-2. **Crie a label** usada por padrão (`bug`) no repositório alvo — sem ela o
-   GitHub responde 422 e a issue não é criada. A lista vem de `ISSUE_LABELS`.
+2. **Crie as labels** usadas por padrão (`bug`, `gui`) no repositório alvo — sem
+   elas o GitHub responde 422 e a issue não é criada. A lista vem de `ISSUE_LABELS`.
 3. **Gere o token compartilhado** com os apps (`API_TOKEN`), por exemplo:
    `openssl rand -hex 32`. Este token será embutido na GUI/standalone quando
    eles ganharem o botão de reportar bug — se vazar, troque o valor e o
@@ -45,7 +45,7 @@ Variáveis (todas em `.env.example`):
 | `API_TOKEN` | sim | — | segredo compartilhado com os apps (Bearer) |
 | `GITHUB_TOKEN` | sim | — | PAT com permissão Issues: write no repo alvo |
 | `GITHUB_REPO` | não | `bezumiya/GoLiveBypass` | `owner/repo` da issue |
-| `ISSUE_LABELS` | não | `bug` | labels separadas por vírgula (precisam existir no repo) |
+| `ISSUE_LABELS` | não | `bug,gui` | labels separadas por vírgula (precisam existir no repo) |
 | `PORT` | não | `8080` | porta HTTP |
 | `RATE_LIMIT` | não | `60` | requisições por minuto por IP |
 | `MAX_LOG_BYTES` | não | `262144` | teto do campo `log` (256 KB) |
@@ -145,9 +145,19 @@ Cobertura: validação do payload e montagem do markdown (`internal/bugreport`),
 cliente GitHub contra um fake HTTP (`internal/gh`), e os endpoints completos
 com auth, rate limit, body limit e erros (`internal/server`).
 
-## Integração futura (fora deste escopo)
+## Integração com a GUI
 
-A GUI (Electron) e o standalone ganharão um botão **"Reportar bug"** que
-monta o relato — com o `golivebypass.log` e os metadados do sistema — e chama
-`POST /v1/reports` com o `API_TOKEN` embutido. A resposta traz a URL da issue
-para mostrar ao usuário.
+A GUI Electron tem o botão **Reportar bug** (modo desenvolvedor). Se
+`%LOCALAPPDATA%\GoLiveBypass\settings.json` (ou o equivalente em Linux/Mac)
+contiver:
+
+```json
+{
+  "bugReportApiUrl": "https://sua-api.exemplo.com",
+  "bugReportToken": "<mesmo valor de API_TOKEN>"
+}
+```
+
+(ou as variáveis de ambiente `GOLIVE_BUG_API_URL` / `GOLIVE_BUG_API_TOKEN`), ela
+chama `POST /v1/reports` e abre a issue criada. Sem isso, cai no formulário
+`github.com/.../issues/new` com o diagnóstico no clipboard.

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -39,7 +39,7 @@ func Load() (*Config, error) {
 	if !strings.Contains(cfg.GitHubRepo, "/") {
 		return nil, fmt.Errorf("GITHUB_REPO deve estar no formato owner/repo (recebido %q)", cfg.GitHubRepo)
 	}
-	cfg.Labels = splitCSV(getenv("ISSUE_LABELS", "bug"))
+	cfg.Labels = splitCSV(getenv("ISSUE_LABELS", "bug,gui"))
 	return cfg, nil
 }
 

--- a/api/internal/config/config_test.go
+++ b/api/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 func TestLoadDefaults(t *testing.T) {
 	t.Setenv("API_TOKEN", "app-secret")
 	t.Setenv("GITHUB_TOKEN", "gh-secret")
+	t.Setenv("ISSUE_LABELS", "") // forca o default
 
 	cfg, err := Load()
 	if err != nil {
@@ -25,8 +26,8 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.MaxLogBytes != 262144 {
 		t.Errorf("MaxLogBytes = %d, want 262144", cfg.MaxLogBytes)
 	}
-	if !reflect.DeepEqual(cfg.Labels, []string{"bug"}) {
-		t.Errorf("Labels = %v, want [bug]", cfg.Labels)
+	if !reflect.DeepEqual(cfg.Labels, []string{"bug", "gui"}) {
+		t.Errorf("Labels = %v, want [bug gui]", cfg.Labels)
 	}
 }
 
@@ -88,7 +89,7 @@ func TestLoadOverrides(t *testing.T) {
 	}
 }
 
-func TestLoadEmptyLabelsFallsBackToBug(t *testing.T) {
+func TestLoadEmptyLabelsFallsBackToBugGui(t *testing.T) {
 	t.Setenv("API_TOKEN", "app-secret")
 	t.Setenv("GITHUB_TOKEN", "gh-secret")
 	t.Setenv("ISSUE_LABELS", "")
@@ -97,7 +98,7 @@ func TestLoadEmptyLabelsFallsBackToBug(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	if !reflect.DeepEqual(cfg.Labels, []string{"bug"}) {
-		t.Errorf("Labels = %v, want [bug]", cfg.Labels)
+	if !reflect.DeepEqual(cfg.Labels, []string{"bug", "gui"}) {
+		t.Errorf("Labels = %v, want [bug gui]", cfg.Labels)
 	}
 }

--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -6,6 +6,7 @@ import {
   nativeImage,
   Tray,
   shell,
+  clipboard,
 } from "electron";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -82,6 +83,8 @@ const MAC_HELPER_PROCESSES = [
 ];
 
 let mainWindow: BrowserWindow | null = null;
+let logWindow: BrowserWindow | null = null;
+let suppressLogClosedNotify = false;
 let tray: Tray | null = null;
 
 // Fechar a janela esconde na bandeja (Windows) / barra de menus (Mac); so o Sair do menu
@@ -262,11 +265,95 @@ function createWindow() {
   }
 }
 
+function loadLogsPage(win: BrowserWindow) {
+  if (process.env.VITE_DEV_SERVER_URL) {
+    const base = process.env.VITE_DEV_SERVER_URL.replace(/\/?$/, "/");
+    win.loadURL(`${base}logs.html`);
+  } else {
+    win.loadFile(path.join(__dirname, "../dist/logs.html"));
+  }
+}
+
+function closeLogWindow() {
+  if (!logWindow || logWindow.isDestroyed()) {
+    logWindow = null;
+    return;
+  }
+  // Fecha pelo toggle: nao manda o evento que desligaria o switch de novo.
+  suppressLogClosedNotify = true;
+  const win = logWindow;
+  logWindow = null;
+  try {
+    win.destroy();
+  } catch {
+    /* ignore */
+  }
+}
+
+function openLogWindow() {
+  if (logWindow && !logWindow.isDestroyed()) {
+    logWindow.show();
+    logWindow.focus();
+    return;
+  }
+
+  // Ao lado da janela principal, sem alongar a UI principal.
+  let x: number | undefined;
+  let y: number | undefined;
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    const [mx, my] = mainWindow.getPosition();
+    const [mw] = mainWindow.getSize();
+    x = mx + mw + 12;
+    y = my;
+  }
+
+  logWindow = new BrowserWindow({
+    width: 520,
+    height: 560,
+    x,
+    y,
+    minWidth: 420,
+    minHeight: 360,
+    resizable: true,
+    icon: loadAsset("icon.png"),
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+    autoHideMenuBar: true,
+    titleBarStyle: isMac ? "hiddenInset" : "hidden",
+    ...(isMac
+      ? { trafficLightPosition: { x: 8, y: 8 }, useContentSize: true }
+      : { titleBarOverlay: TITLEBAR[theme] }),
+  });
+
+  logWindow.setTitle("GoLiveBypass — Logs");
+  logWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (/^https:\/\//.test(url)) void shell.openExternal(url);
+    return { action: "deny" };
+  });
+
+  logWindow.on("closed", () => {
+    logWindow = null;
+    stopLogWatch();
+    if (!suppressLogClosedNotify && mainWindow && !mainWindow.isDestroyed() && !quitting) {
+      mainWindow.webContents.send("dev-log-window-closed");
+    }
+    suppressLogClosedNotify = false;
+  });
+
+  loadLogsPage(logWindow);
+}
+
 // A janela precisa refletir o que a bandeja fez; sem isto, ativar/desativar pelo icone deixava
 // a interface com o estado antigo (botao "Ativar" com o bypass ja ativo, por exemplo).
 function refreshWindowStatus() {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send('refresh-status');
+    mainWindow.webContents.send("refresh-status");
+  }
+  if (logWindow && !logWindow.isDestroyed()) {
+    logWindow.webContents.send("refresh-status");
   }
 }
 
@@ -473,6 +560,8 @@ app.on("before-quit", (event) => {
   cleaningUp = true;
   // O Tor embutido morre junto com o app (e o Discord restaurado nao fica dependente dele).
   stopTor();
+  closeLogWindow();
+  stopLogWatch();
   // Reversao em background: o runScript roda detached/unref, entao o filho sobrevive ao
   // app.quit() e o Discord nao fica com a injecao pendurada. Sem esperar: o "Sair" sai na
   // hora mesmo se o script demorar (fechar o Discord, flatpak, sudo...).
@@ -1579,6 +1668,656 @@ ipcMain.handle("install-tor", async () => {
   return r.ok ? { ok: true, porta: r.porta } : { ok: false, error: r.error };
 });
 
+// ------------------------------------------------------------------ teste de proxy (Personalizado / VPS)
+// A mesma pergunta do Tor: esta saida abre tunel ate o gateway? Sem isto a pessoa cola um
+// endereco errado, ativa o bypass e o Discord fica carregando sem saber por que.
+
+const PROXY_URL_RE =
+  /^(socks5|socks4|http|https):\/\/(?:(.+)@)?([^:/?#\s@]+):(\d{1,5})$/i;
+
+function parseProxyUrl(value: string): {
+  scheme: string;
+  user: string;
+  pass: string;
+  host: string;
+  port: number;
+} | null {
+  const match = PROXY_URL_RE.exec(String(value).trim());
+  if (!match) return null;
+  const port = Number(match[4]);
+  if (port < 1 || port > 65535) return null;
+
+  const credentials = match[2] ?? "";
+  const split = credentials.indexOf(":");
+  const decode = (raw: string) => {
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw;
+    }
+  };
+
+  return {
+    scheme: match[1].toLowerCase(),
+    user: credentials === "" ? "" : decode(split < 0 ? credentials : credentials.slice(0, split)),
+    pass: credentials === "" || split < 0 ? "" : decode(credentials.slice(split + 1)),
+    host: match[3],
+    port,
+  };
+}
+
+function openSocks5Tunnel(
+  proxyHost: string,
+  proxyPort: number,
+  user: string,
+  pass: string,
+  destHost: string,
+  destPort: number,
+  timeoutMs = 12_000,
+): Promise<import("net").Socket | null> {
+  return new Promise((resolve) => {
+    const net = require("net") as typeof import("net");
+    const s = net.connect({ host: proxyHost, port: proxyPort });
+    let etapa: "saudacao" | "auth" | "resposta" = "saudacao";
+    let buf = Buffer.alloc(0);
+    let settled = false;
+
+    const fim = (sock: import("net").Socket | null) => {
+      if (settled) return;
+      settled = true;
+      s.setTimeout(0);
+      s.removeAllListeners();
+      if (sock === null) s.destroy();
+      resolve(sock);
+    };
+
+    const enviarConnect = () => {
+      buf = Buffer.alloc(0);
+      const alvo = Buffer.from(destHost, "utf8");
+      s.write(
+        Buffer.concat([
+          Buffer.from([0x05, 0x01, 0x00, 0x03, alvo.length]),
+          alvo,
+          Buffer.from([(destPort >> 8) & 0xff, destPort & 0xff]),
+        ]),
+      );
+      etapa = "resposta";
+    };
+
+    s.setTimeout(timeoutMs, () => fim(null));
+    s.on("error", () => fim(null));
+    s.on("close", () => {
+      if (!settled) fim(null);
+    });
+
+    s.on("connect", () => {
+      if (user === "") s.write(Buffer.from([0x05, 0x01, 0x00]));
+      else s.write(Buffer.from([0x05, 0x02, 0x00, 0x02]));
+    });
+
+    s.on("data", (chunk: Buffer) => {
+      buf = Buffer.concat([buf, chunk]);
+
+      if (etapa === "saudacao") {
+        if (buf.length < 2) return;
+        if (buf[0] !== 0x05) return fim(null);
+        const metodo = buf[1];
+        buf = buf.subarray(2);
+
+        if (metodo === 0x02) {
+          const u = Buffer.from(user, "utf8");
+          const p = Buffer.from(pass, "utf8");
+          if (u.length > 255 || p.length > 255) return fim(null);
+          etapa = "auth";
+          s.write(
+            Buffer.concat([
+              Buffer.from([0x01, u.length]),
+              u,
+              Buffer.from([p.length]),
+              p,
+            ]),
+          );
+          return;
+        }
+        if (metodo !== 0x00) return fim(null);
+        enviarConnect();
+        return;
+      }
+
+      if (etapa === "auth") {
+        if (buf.length < 2) return;
+        if (buf[1] !== 0x00) return fim(null);
+        buf = buf.subarray(2);
+        enviarConnect();
+        return;
+      }
+
+      if (etapa === "resposta") {
+        // VER REP RSV ATYP + ADDR + PORT
+        if (buf.length < 4) return;
+        if (buf[0] !== 0x05 || buf[1] !== 0x00) return fim(null);
+        const atyp = buf[3];
+        let headerLen = 4;
+        if (atyp === 0x01) headerLen = 10;
+        else if (atyp === 0x03) {
+          if (buf.length < 5) return;
+          headerLen = 5 + buf[4] + 2;
+        } else if (atyp === 0x04) headerLen = 22;
+        else return fim(null);
+        if (buf.length < headerLen) return;
+        const leftover = buf.subarray(headerLen);
+        if (leftover.length > 0) s.unshift(leftover);
+        fim(s);
+      }
+    });
+  });
+}
+
+function readHttpOverTls(
+  socket: import("net").Socket,
+  host: string,
+  reqPath: string,
+  timeoutMs = 10_000,
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    const tls = require("tls") as typeof import("tls");
+    let body = "";
+    let settled = false;
+    const fim = (v: string | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        tlsSock.destroy();
+      } catch {
+        /* ignore */
+      }
+      resolve(v);
+    };
+
+    const timer = setTimeout(() => fim(null), timeoutMs);
+    const tlsSock = tls.connect({ socket, servername: host, host }, () => {
+      tlsSock.write(
+        `GET ${reqPath} HTTP/1.1\r\nHost: ${host}\r\nAccept: */*\r\nConnection: close\r\n\r\n`,
+      );
+    });
+    tlsSock.setEncoding("latin1");
+    tlsSock.on("error", () => fim(null));
+    tlsSock.on("data", (chunk: string) => {
+      body += chunk;
+      if (body.length > 65536) fim(body);
+    });
+    tlsSock.on("end", () => fim(body || null));
+  });
+}
+
+async function exitCountryViaSocks(
+  proxyHost: string,
+  proxyPort: number,
+  user: string,
+  pass: string,
+): Promise<string | null> {
+  // Mesma estrategia do bypass: Cloudflare /cdn-cgi/trace, fallback ipwho.is (Tor = loc=T1).
+  const geoHost = "cloudflare.com";
+  const sock = await openSocks5Tunnel(proxyHost, proxyPort, user, pass, geoHost, 443, 10_000);
+  if (sock) {
+    const response = await readHttpOverTls(sock, geoHost, "/cdn-cgi/trace");
+    sock.destroy();
+    const match = response ? /^loc=([A-Z]{2})/m.exec(response) : null;
+    if (match && match[1] !== "T1") return match[1];
+  }
+
+  try {
+    const fallbackHost = "ipwho.is";
+    const fb = await openSocks5Tunnel(
+      proxyHost,
+      proxyPort,
+      user,
+      pass,
+      fallbackHost,
+      443,
+      10_000,
+    );
+    if (fb) {
+      const json = await readHttpOverTls(fb, fallbackHost, "/?fields=country_code");
+      fb.destroy();
+      const iso = json ? /"country_code"\s*:\s*"([A-Z]{2})"/.exec(json) : null;
+      if (iso) return iso[1];
+    }
+  } catch {
+    /* sem pais */
+  }
+  return null;
+}
+
+ipcMain.handle("test-proxy", async (_event, proxyRaw: unknown) => {
+  const raw = typeof proxyRaw === "string" ? proxyRaw.trim() : "";
+  if (raw === "") {
+    return { ok: false, error: "Cole o endereco da proxy (socks5://host:porta)." };
+  }
+
+  const parsed = parseProxyUrl(raw);
+  if (!parsed) {
+    return {
+      ok: false,
+      error: "Formato invalido. Use socks5://host:porta ou socks5://usuario:senha@host:porta.",
+    };
+  }
+
+  if (parsed.scheme !== "socks5") {
+    return {
+      ok: false,
+      error: `Por enquanto o teste so cobre SOCKS5 (voce usou ${parsed.scheme}).`,
+    };
+  }
+
+  const t0 = Date.now();
+  const tunnel = await openSocks5Tunnel(
+    parsed.host,
+    parsed.port,
+    parsed.user,
+    parsed.pass,
+    TOR_ALVO_HOST,
+    TOR_ALVO_PORTA,
+  );
+  const ms = Date.now() - t0;
+
+  if (!tunnel) {
+    return {
+      ok: false,
+      error: "Nao abriu tunel ate gateway.discord.gg. Confira IP, porta, firewall e se a saida nao e BR.",
+      ms,
+    };
+  }
+  tunnel.destroy();
+
+  const country = await exitCountryViaSocks(
+    parsed.host,
+    parsed.port,
+    parsed.user,
+    parsed.pass,
+  );
+
+  if (country === "BR") {
+    return {
+      ok: false,
+      error: `Tunel OK (${ms}ms), mas a saida e BR — o Discord continua bloqueando Go Live. Use VPS/Tor fora do Brasil.`,
+      ms,
+      country,
+      host: parsed.host,
+      port: parsed.port,
+    };
+  }
+
+  return {
+    ok: true,
+    ms,
+    country: country ?? undefined,
+    host: parsed.host,
+    port: parsed.port,
+  };
+});
+
+// ------------------------------------------------------------------ diagnostico / modo dev
+const ISSUE_REPO = "bezumiya/GoLiveBypass";
+// A label "gui" precisa existir no repo (criar uma vez no GitHub). Sem ela o form ainda abre;
+// a API de reports usa ISSUE_LABELS no servidor.
+const ISSUE_LABELS = ["bug", "gui"];
+
+function logFilePath() {
+  return path.join(settingsDir(), "golivebypass.log");
+}
+
+function maskSecrets(text: string): string {
+  return text
+    .replace(
+      /(socks5|socks4|https?|http):\/\/([^/\s@]+)@/gi,
+      (_m, scheme: string, creds: string) => {
+        const user = creds.split(":")[0] || "user";
+        return `${scheme}://${user}:***@`;
+      },
+    )
+    .replace(/(pass|password|senha)\s*[:=]\s*\S+/gi, "$1=***");
+}
+
+function readLogTail(maxBytes = 48_000): string {
+  const file = logFilePath();
+  try {
+    if (!fs.existsSync(file)) return "(ainda nao ha golivebypass.log — ative o bypass uma vez)";
+    const size = fs.statSync(file).size;
+    const start = Math.max(0, size - maxBytes);
+    const fd = fs.openSync(file, "r");
+    try {
+      const buf = Buffer.alloc(size - start);
+      fs.readSync(fd, buf, 0, buf.length, start);
+      const text = buf.toString("utf8");
+      return start > 0 ? `… (trecho final)\n${text}` : text;
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch (error) {
+    return `(nao consegui ler o log: ${error instanceof Error ? error.message : String(error)})`;
+  }
+}
+
+function buildDiagnostic(status: string, extraNote = ""): string {
+  const proxy = maskSecrets(
+    readProxyFrom(path.join(settingsDir(), "settings.json")) || "(vazio)",
+  );
+  const lines = [
+    "### Diagnóstico GoLiveBypass (GUI)",
+    "",
+    "| | |",
+    "|---|---|",
+    `| app | golive-gui ${app.getVersion()} |`,
+    `| os | ${process.platform} ${process.arch} |`,
+    `| electron | ${process.versions.electron} |`,
+    `| status | ${status} |`,
+    `| routeMode | ${readNetMode()} |`,
+    `| proxy | ${proxy} |`,
+    `| torPort | ${torPortaEmUso} (verificado=${torVerificado}) |`,
+    `| log | \`${logFilePath()}\` |`,
+    "",
+  ];
+  if (extraNote.trim()) {
+    lines.push("**Relato:**", "", extraNote.trim(), "");
+  }
+  lines.push("**Log (trecho):**", "", "```", maskSecrets(readLogTail()), "```", "");
+  lines.push(
+    "_Senhas mascaradas. Se o corpo da issue ficar curto demais, cole o diagnóstico completo do clipboard._",
+  );
+  return lines.join("\n");
+}
+
+let logWatchOffset = 0;
+let logWatchActive = false;
+
+function stopLogWatch() {
+  logWatchActive = false;
+  try {
+    fs.unwatchFile(logFilePath());
+  } catch {
+    /* ignore */
+  }
+}
+
+function pushLogChunk(chunk: string) {
+  if (!chunk) return;
+  if (logWindow && !logWindow.isDestroyed()) {
+    logWindow.webContents.send("log-chunk", chunk);
+  }
+}
+
+function startLogWatch() {
+  stopLogWatch();
+  const file = logFilePath();
+  try {
+    fs.mkdirSync(settingsDir(), { recursive: true });
+  } catch {
+    /* ignore */
+  }
+
+  logWatchActive = true;
+  try {
+    if (fs.existsSync(file)) {
+      const size = fs.statSync(file).size;
+      // Manda o final do arquivo de uma vez, depois so o que chegar.
+      const start = Math.max(0, size - 24_000);
+      logWatchOffset = start;
+      const fd = fs.openSync(file, "r");
+      try {
+        const buf = Buffer.alloc(size - start);
+        if (buf.length > 0) {
+          fs.readSync(fd, buf, 0, buf.length, start);
+          pushLogChunk(buf.toString("utf8"));
+        }
+      } finally {
+        fs.closeSync(fd);
+      }
+      logWatchOffset = size;
+    } else {
+      logWatchOffset = 0;
+      pushLogChunk("(aguardando golivebypass.log — aparece quando o Discord roda com o bypass)\n");
+    }
+  } catch (error) {
+    pushLogChunk(
+      `(erro ao abrir log: ${error instanceof Error ? error.message : String(error)})\n`,
+    );
+  }
+
+  fs.watchFile(file, { interval: 700 }, (curr, prev) => {
+    if (!logWatchActive) return;
+    try {
+      if (!fs.existsSync(file)) {
+        logWatchOffset = 0;
+        return;
+      }
+      if (curr.size < logWatchOffset) logWatchOffset = 0; // rotacao / truncate
+      if (curr.size === logWatchOffset) return;
+      if (curr.mtimeMs === prev.mtimeMs && curr.size === prev.size) return;
+
+      const fd = fs.openSync(file, "r");
+      try {
+        const len = curr.size - logWatchOffset;
+        const buf = Buffer.alloc(len);
+        fs.readSync(fd, buf, 0, len, logWatchOffset);
+        logWatchOffset = curr.size;
+        pushLogChunk(buf.toString("utf8"));
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      /* ignore race */
+    }
+  });
+}
+
+ipcMain.handle("start-log-watch", () => {
+  startLogWatch();
+  return { path: logFilePath() };
+});
+
+ipcMain.handle("stop-log-watch", () => {
+  stopLogWatch();
+  return true;
+});
+
+ipcMain.handle("get-diagnostic", (_event, payload: unknown) => {
+  const p = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const status = typeof p.status === "string" ? p.status : "UNKNOWN";
+  const note = typeof p.note === "string" ? p.note : "";
+  return {
+    text: buildDiagnostic(status, note),
+    logPath: logFilePath(),
+    apiConfigured: Boolean(readBugReportConfig()),
+  };
+});
+
+function readBugReportConfig(): { baseUrl: string; token: string } | null {
+  // Prioridade: settings.json da pasta compartilhada, depois env do processo.
+  // Sem os dois, o botao cai no form do GitHub (sem segredo embutido no binario).
+  let url = (process.env.GOLIVE_BUG_API_URL || "").trim().replace(/\/$/, "");
+  let token = (process.env.GOLIVE_BUG_API_TOKEN || "").trim();
+  try {
+    const file = path.join(settingsDir(), "settings.json");
+    if (fs.existsSync(file)) {
+      const data = JSON.parse(fs.readFileSync(file, "utf8"));
+      if (typeof data.bugReportApiUrl === "string" && data.bugReportApiUrl.trim()) {
+        url = data.bugReportApiUrl.trim().replace(/\/$/, "");
+      }
+      if (typeof data.bugReportToken === "string" && data.bugReportToken.trim()) {
+        token = data.bugReportToken.trim();
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  if (!url || !token) return null;
+  return { baseUrl: url, token };
+}
+
+async function postBugReportToApi(
+  cfg: { baseUrl: string; token: string },
+  title: string,
+  description: string,
+  status: string,
+): Promise<{ ok: true; issueUrl: string; issueNumber?: number } | { ok: false; error: string }> {
+  const endpoint = `${cfg.baseUrl}/v1/reports`;
+  const body = {
+    title,
+    description,
+    log: maskSecrets(readLogTail(200_000)),
+    meta: {
+      app: "golive-gui",
+      version: app.getVersion(),
+      os: `${process.platform} ${process.arch}`,
+      electron: process.versions.electron ?? "",
+      status,
+      routeMode: readNetMode(),
+    },
+  };
+
+  try {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${cfg.token}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    let data: Record<string, unknown> = {};
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      /* corpo nao-json */
+    }
+
+    if (!res.ok) {
+      const err =
+        typeof data.error === "string"
+          ? data.error
+          : `API respondeu ${res.status}`;
+      return { ok: false, error: err };
+    }
+
+    const issueUrl =
+      typeof data.issue_url === "string"
+        ? data.issue_url
+        : typeof data.html_url === "string"
+          ? data.html_url
+          : "";
+    if (!issueUrl) return { ok: false, error: "API nao devolveu issue_url" };
+    return {
+      ok: true,
+      issueUrl,
+      issueNumber: typeof data.issue_number === "number" ? data.issue_number : undefined,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+ipcMain.handle("open-bug-report", async (_event, payload: unknown) => {
+  const p = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const status = typeof p.status === "string" ? p.status : "UNKNOWN";
+  const note =
+    typeof p.note === "string" && p.note.trim()
+      ? p.note.trim()
+      : "(descreva o que aconteceu, o que esperava, e se câmera / Go Live / região da call)";
+  const titleRaw =
+    typeof p.title === "string" && p.title.trim()
+      ? p.title.trim()
+      : `[GUI] problema com bypass (${status})`;
+  const title = titleRaw.slice(0, 180);
+
+  const fullBody = buildDiagnostic(status, note);
+  clipboard.writeText(fullBody);
+
+  // 1) API (log completo, labels no servidor) — se configurada.
+  const apiCfg = readBugReportConfig();
+  if (apiCfg) {
+    const posted = await postBugReportToApi(apiCfg, title, note, status);
+    if (posted.ok) {
+      await shell.openExternal(posted.issueUrl);
+      return {
+        ok: true,
+        via: "api" as const,
+        url: posted.issueUrl,
+        issueNumber: posted.issueNumber,
+        copied: true,
+        truncated: false,
+      };
+    }
+    // Cai no form do GitHub, mas avisa o motivo no retorno.
+    const maxBody = 5500;
+    const bodyForUrl =
+      fullBody.length > maxBody
+        ? `${fullBody.slice(0, maxBody)}\n\n…(truncado — cole o diagnóstico do clipboard)\n\n_API falhou: ${posted.error}_`
+        : `${fullBody}\n\n_API falhou: ${posted.error}_`;
+    const params = new URLSearchParams({
+      title,
+      body: bodyForUrl,
+      labels: ISSUE_LABELS.join(","),
+    });
+    const url = `https://github.com/${ISSUE_REPO}/issues/new?${params.toString()}`;
+    await shell.openExternal(url);
+    return {
+      ok: true,
+      via: "github" as const,
+      url,
+      copied: true,
+      truncated: fullBody.length > maxBody,
+      apiError: posted.error,
+    };
+  }
+
+  // 2) Fallback: form do GitHub (sem token no app).
+  const maxBody = 5500;
+  const bodyForUrl =
+    fullBody.length > maxBody
+      ? `${fullBody.slice(0, maxBody)}\n\n…(truncado — cole o diagnóstico completo do clipboard)`
+      : fullBody;
+
+  const params = new URLSearchParams({
+    title,
+    body: bodyForUrl,
+    labels: ISSUE_LABELS.join(","),
+  });
+  const url = `https://github.com/${ISSUE_REPO}/issues/new?${params.toString()}`;
+  await shell.openExternal(url);
+
+  return {
+    ok: true,
+    via: "github" as const,
+    url,
+    copied: true,
+    truncated: fullBody.length > maxBody,
+  };
+});
+
+ipcMain.handle("open-log-folder", async () => {
+  const dir = settingsDir();
+  fs.mkdirSync(dir, { recursive: true });
+  await shell.openPath(dir);
+  return dir;
+});
+
+ipcMain.handle("set-dev-log-window", (_event, open: unknown) => {
+  if (open === true) {
+    openLogWindow();
+    return true;
+  }
+  closeLogWindow();
+  stopLogWatch();
+  return false;
+});
+
 ipcMain.handle("get-proxy", () => {
   const salva = readProxyFrom(path.join(settingsDir(), "settings.json"));
   if (salva !== "") return salva;
@@ -1601,14 +2340,15 @@ ipcMain.handle("get-proxy", () => {
   return "";
 });
 
-// A pagina reporta a altura de que precisa (o warning do bypass ativo faz o conteudo crescer).
-// A janela e fixa (resizable: false), entao o proprio app ajusta para caber tudo sem cortar.
-ipcMain.on('resize-window', (_event, height: unknown) => {
-  const h = Number(height);
+// A pagina reporta a ALTURA DO CONTEUDO. Com titleBarOverlay, setSize (janela externa)
+// nao casa com essa medida: a janela crescia no Personalizado e nao encolhia ao voltar.
+// setContentSize ajusta a area cliente — a mesma que o getBoundingClientRect mede.
+ipcMain.on("resize-window", (_event, height: unknown) => {
+  const h = Math.round(Number(height));
   if (!mainWindow || mainWindow.isDestroyed() || !Number.isFinite(h) || h <= 0) return;
-  const [, currentH] = mainWindow.getSize();
-  if (Math.abs(currentH - Math.round(h)) < 2) return;
-  mainWindow.setSize(480, Math.round(h));
+  const [, contentH] = mainWindow.getContentSize();
+  if (Math.abs(contentH - h) < 2) return;
+  mainWindow.setContentSize(480, h);
 });
 
 // O renderer avisa quando o tema muda para o overlay da barra de titulo
@@ -1617,4 +2357,7 @@ ipcMain.on('set-theme', (_event, value: unknown) => {
   if (value !== 'light' && value !== 'dark') return;
   theme = value;
   applyTitlebarTheme();
+  if (logWindow && !logWindow.isDestroyed() && !isMac) {
+    logWindow.setTitleBarOverlay(TITLEBAR[theme]);
+  }
 });

--- a/golive-gui/electron/preload.ts
+++ b/golive-gui/electron/preload.ts
@@ -13,6 +13,21 @@ import { ipcRenderer } from 'electron';
   setNetMode: (mode: string) => ipcRenderer.invoke('set-net-mode', mode),
   getTorStatus: () => ipcRenderer.invoke('get-tor-status'),
   installTor: () => ipcRenderer.invoke('install-tor'),
+  testProxy: (proxy: string) => ipcRenderer.invoke('test-proxy', proxy),
+  startLogWatch: () => ipcRenderer.invoke('start-log-watch'),
+  stopLogWatch: () => ipcRenderer.invoke('stop-log-watch'),
+  getDiagnostic: (payload: { status: string; note?: string }) =>
+    ipcRenderer.invoke('get-diagnostic', payload),
+  openBugReport: (payload: { status: string; note?: string; title?: string }) =>
+    ipcRenderer.invoke('open-bug-report', payload),
+  openLogFolder: () => ipcRenderer.invoke('open-log-folder'),
+  setDevLogWindow: (open: boolean) => ipcRenderer.invoke('set-dev-log-window', open),
+  onLogChunk: (callback: (chunk: string) => void) => {
+    ipcRenderer.on('log-chunk', (_event, chunk: string) => callback(chunk));
+  },
+  onDevLogWindowClosed: (callback: () => void) => {
+    ipcRenderer.on('dev-log-window-closed', () => callback());
+  },
   onRefreshStartup: (callback: () => void) => ipcRenderer.on('refresh-startup', callback),
   onRefreshStatus: (callback: () => void) => ipcRenderer.on('refresh-status', callback),
   resizeWindow: (height: number) => ipcRenderer.send('resize-window', height),

--- a/golive-gui/index.html
+++ b/golive-gui/index.html
@@ -8,10 +8,11 @@
       // Aplica o tema antes do CSS carregar para nao piscar claro.
       // Padrao: dark; respeita o que o usuario salvou.
       try {
-        var t = localStorage.getItem('golivebypass-theme');
-        document.documentElement.dataset.theme = t === 'light' ? 'light' : 'dark';
+        var t = localStorage.getItem("golivebypass-theme");
+        document.documentElement.dataset.theme =
+          t === "light" ? "light" : "dark";
       } catch (e) {
-        document.documentElement.dataset.theme = 'dark';
+        document.documentElement.dataset.theme = "dark";
       }
     </script>
   </head>
@@ -26,14 +27,22 @@
           <div class="header-top">
             <div class="wordmark-group">
               <span class="wordmark">
-                <img class="logo" src="./assets/logo.svg" alt="" aria-hidden="true" draggable="false" />
+                <img
+                  class="logo"
+                  src="./assets/logo.svg"
+                  alt=""
+                  aria-hidden="true"
+                  draggable="false"
+                />
                 GoLiveBypass
               </span>
               <span class="meta">Go Live &middot; Brasil</span>
             </div>
           </div>
 
-          <p class="tagline">Devolve o Go Live e a c&acirc;mera no Discord, no Brasil.</p>
+          <p class="tagline">
+            Devolve o Go Live e a c&acirc;mera no Discord, no Brasil.
+          </p>
         </header>
 
         <!-- Acoes fixas nos cantos da janela (fora do fluxo do container) -->
@@ -47,22 +56,44 @@
             aria-controls="warningAlert"
             data-tip="Aviso"
           >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
-              <path d="M12 9v4"/>
-              <path d="M12 17h.01"/>
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path
+                d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"
+              />
+              <path d="M12 9v4" />
+              <path d="M12 17h.01" />
             </svg>
           </button>
 
           <div id="warningAlert" class="warning-alert" role="status">
-            <svg class="warn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
-              <path d="M12 9v4"/>
-              <path d="M12 17h.01"/>
+            <svg
+              class="warn-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path
+                d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"
+              />
+              <path d="M12 9v4" />
+              <path d="M12 17h.01" />
             </svg>
             <p>
-              <strong>Aviso:</strong> Se a transmiss&atilde;o ficar preta ou n&atilde;o carregar,
-              aperte <kbd id="reloadKeys">Ctrl + R</kbd> no Discord.
+              <strong>Aviso:</strong> Se a transmiss&atilde;o ficar preta ou
+              n&atilde;o carregar, aperte <kbd id="reloadKeys">Ctrl + R</kbd> no
+              Discord.
             </p>
           </div>
         </div>
@@ -76,7 +107,9 @@
           data-tip="Suporte"
         >
           <svg viewBox="0 0 127.14 96.36" aria-hidden="true">
-            <path d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a67.55,67.55,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1,105.25,105.25,0,0,0,32.19-16.14c2.64-27.38-4.51-51.11-18.9-80.15ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.31,60,73.31,53s5-12.74,11.43-12.74S96.33,46,96.22,53,91.08,65.69,84.69,65.69Z"/>
+            <path
+              d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a67.55,67.55,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1,105.25,105.25,0,0,0,32.19-16.14c2.64-27.38-4.51-51.11-18.9-80.15ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.31,60,73.31,53s5-12.74,11.43-12.74S96.33,46,96.22,53,91.08,65.69,84.69,65.69Z"
+            />
           </svg>
         </a>
 
@@ -87,19 +120,37 @@
           aria-label="Alternar tema claro/escuro"
           data-tip="Tema"
         >
-          <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
+          <svg
+            class="icon-moon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
           </svg>
-          <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="4"/>
-            <path d="M12 2v2"/>
-            <path d="M12 20v2"/>
-            <path d="m4.93 4.93 1.41 1.41"/>
-            <path d="m17.66 17.66 1.41 1.41"/>
-            <path d="M2 12h2"/>
-            <path d="M20 12h2"/>
-            <path d="m6.34 17.66-1.41 1.41"/>
-            <path d="m19.07 4.93-1.41 1.41"/>
+          <svg
+            class="icon-sun"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2" />
+            <path d="M12 20v2" />
+            <path d="m4.93 4.93 1.41 1.41" />
+            <path d="m17.66 17.66 1.41 1.41" />
+            <path d="M2 12h2" />
+            <path d="M20 12h2" />
+            <path d="m6.34 17.66-1.41 1.41" />
+            <path d="m19.07 4.93-1.41 1.41" />
           </svg>
         </button>
 
@@ -110,11 +161,23 @@
         </div>
 
         <button id="toggleBtn" class="toggle-btn" disabled>
-          <svg class="btn-icon icon-play" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M8 5.14v13.72a1 1 0 0 0 1.5.86l11-6.86a1 1 0 0 0 0-1.72l-11-6.86A1 1 0 0 0 8 5.14Z"/>
+          <svg
+            class="btn-icon icon-play"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              d="M8 5.14v13.72a1 1 0 0 0 1.5.86l11-6.86a1 1 0 0 0 0-1.72l-11-6.86A1 1 0 0 0 8 5.14Z"
+            />
           </svg>
-          <svg class="btn-icon icon-stop" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <rect x="6" y="6" width="12" height="12" rx="2"/>
+          <svg
+            class="btn-icon icon-stop"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <rect x="6" y="6" width="12" height="12" rx="2" />
           </svg>
           <span class="btn-text" id="btnText">Carregando</span>
           <div class="spinner" id="btnSpinner" aria-hidden="true"></div>
@@ -129,18 +192,41 @@
         </label>
 
         <div class="net-mode-group">
-          <div class="segmented" id="netModeSegmented" role="radiogroup" aria-label="Rede de saída">
-            <button type="button" class="seg-btn" data-mode="tor" role="radio" aria-checked="true">
+          <div
+            class="segmented"
+            id="netModeSegmented"
+            role="radiogroup"
+            aria-label="Rede de saída"
+          >
+            <button
+              type="button"
+              class="seg-btn"
+              data-mode="tor"
+              role="radio"
+              aria-checked="true"
+            >
               <span class="seg-label">Tor</span>
               <span class="seg-hint">sempre, baixa sozinho</span>
             </button>
-            <button type="button" class="seg-btn" data-mode="free" role="radio" aria-checked="false">
+            <button
+              type="button"
+              class="seg-btn"
+              data-mode="free"
+              role="radio"
+              aria-checked="false"
+            >
               <span class="seg-label">Gratuitas</span>
               <span class="seg-hint">proxies da lista</span>
             </button>
-            <button type="button" class="seg-btn" data-mode="manual" role="radio" aria-checked="false">
+            <button
+              type="button"
+              class="seg-btn"
+              data-mode="manual"
+              role="radio"
+              aria-checked="false"
+            >
               <span class="seg-label">Personalizado</span>
-              <span class="seg-hint">sua proxy</span>
+              <span class="seg-hint">VPS / proxy</span>
             </button>
           </div>
           <small id="torStatus" class="tor-status">Verificando Tor...</small>
@@ -156,14 +242,69 @@
               />
               <label for="proxyInput">socks5://host:porta</label>
             </div>
-            <small>Use socks5://usuario:senha@host:porta se a sua proxy pedir login.</small>
+            <div class="proxy-actions">
+              <button type="button" class="proxy-test-btn" id="proxyTestBtn">
+                Testar conexão
+              </button>
+              <small
+                id="proxyTestStatus"
+                class="proxy-test-status"
+                aria-live="polite"
+              ></small>
+            </div>
+            <details class="vps-guide">
+              <summary>Como montar uma VPS (saída estável)</summary>
+              <ol>
+                <li>
+                  Alugue um VPS barato <strong>fora do Brasil</strong> (Chile,
+                  EUA, etc.).
+                </li>
+                <li>
+                  Instale um SOCKS5 — ex.: <code>dante</code>,
+                  <code>3proxy</code> ou Shadowsocks.
+                </li>
+                <li>
+                  Cole aqui <code>socks5://IP:porta</code> (com usuário se pedir
+                  login).
+                </li>
+                <li>
+                  Clique em <strong>Testar conexão</strong>: tem que abrir túnel
+                  até o gateway do Discord.
+                </li>
+                <li>
+                  Na call, não force a região <strong>Brazil</strong> — a mídia
+                  BR ainda pode derrubar a tela.
+                </li>
+              </ol>
+              <p class="vps-note">
+                Isso não é um servidor local de streams: o Discord só libera o
+                Go Live se o
+                <em>gateway</em> sair com IP de outro país. A VPS é a sua saída,
+                estável e sua.
+              </p>
+            </details>
           </div>
         </div>
+
+        <label class="switch-row">
+          <input type="checkbox" id="devModeToggle" />
+          <span class="switch-track" aria-hidden="true">
+            <span class="switch-thumb"></span>
+          </span>
+          <span>Modo desenvolvedor</span>
+        </label>
+        <small id="devModeHint" class="dev-mode-hint" hidden
+          >Janela de logs aberta ao lado</small
+        >
 
         <footer class="footer">
           <p class="disclaimer">
             O Discord reiniciar&aacute; automaticamente.
-            <span id="closeHint">Fechar a janela esconde o app na bandeja, junto do rel&oacute;gio &mdash; para reverter tudo, saia pelo &iacute;cone de l&aacute;.</span>
+            <span id="closeHint"
+              >Fechar a janela esconde o app na bandeja, junto do rel&oacute;gio
+              &mdash; para reverter tudo, saia pelo &iacute;cone de
+              l&aacute;.</span
+            >
           </p>
           <p class="credits">
             Projeto open source, feito por

--- a/golive-gui/logs.html
+++ b/golive-gui/logs.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GoLiveBypass — Logs</title>
+    <script>
+      try {
+        var t = localStorage.getItem('golivebypass-theme');
+        document.documentElement.dataset.theme = t === 'light' ? 'light' : 'dark';
+      } catch (e) {
+        document.documentElement.dataset.theme = 'dark';
+      }
+    </script>
+  </head>
+  <body class="logs-window">
+    <div class="page-ambient" aria-hidden="true"></div>
+    <div class="drag-region"></div>
+    <div class="logs-shell">
+      <header class="logs-header">
+        <h1>Diagnóstico</h1>
+        <p class="logs-sub">Logs ao vivo e relato de bug</p>
+      </header>
+
+      <div class="dev-toolbar">
+        <button type="button" class="dev-btn" id="reportBugBtn">Reportar bug</button>
+        <button type="button" class="dev-btn" id="copyDiagBtn">Copiar diagnóstico</button>
+        <button type="button" class="dev-btn" id="openLogFolderBtn">Pasta de logs</button>
+      </div>
+
+      <label class="dev-note-label" for="bugNoteInput">O que aconteceu? (vai na issue)</label>
+      <textarea
+        id="bugNoteInput"
+        class="dev-note"
+        rows="2"
+        placeholder="Ex.: câmera ok, Go Live carrega e dá 2012; região da call Brazil; modo Tor."
+      ></textarea>
+
+      <div class="log-console" id="logConsole" aria-live="polite"></div>
+      <small class="dev-hint" id="devHint">Logs ao vivo de golivebypass.log</small>
+    </div>
+    <script type="module" src="/src/logs.ts"></script>
+  </body>
+</html>

--- a/golive-gui/src/logs.ts
+++ b/golive-gui/src/logs.ts
@@ -1,0 +1,123 @@
+import './style.css'
+
+const api = (window as any).api as {
+  getStatus: () => Promise<string>;
+  startLogWatch: () => Promise<{ path: string }>;
+  stopLogWatch: () => Promise<boolean>;
+  getDiagnostic: (payload: { status: string; note?: string }) => Promise<{
+    text: string;
+    logPath: string;
+  }>;
+  openBugReport: (payload: {
+    status: string;
+    note?: string;
+    title?: string;
+  }) => Promise<{
+    ok: boolean;
+    via?: 'api' | 'github';
+    url: string;
+    issueNumber?: number;
+    copied: boolean;
+    truncated: boolean;
+    apiError?: string;
+  }>;
+  openLogFolder: () => Promise<string>;
+  onLogChunk: (callback: (chunk: string) => void) => void;
+  onRefreshStatus: (callback: () => void) => void;
+};
+
+const logConsole = document.getElementById('logConsole')!;
+const bugNoteInput = document.getElementById('bugNoteInput') as HTMLTextAreaElement;
+const reportBugBtn = document.getElementById('reportBugBtn') as HTMLButtonElement;
+const copyDiagBtn = document.getElementById('copyDiagBtn') as HTMLButtonElement;
+const openLogFolderBtn = document.getElementById('openLogFolderBtn') as HTMLButtonElement;
+const devHint = document.getElementById('devHint')!;
+
+const MAX_LOG_CHARS = 120_000;
+let currentStatus = 'UNKNOWN';
+
+function appendLog(chunk: string) {
+  logConsole.textContent += chunk;
+  if (logConsole.textContent.length > MAX_LOG_CHARS) {
+    logConsole.textContent = logConsole.textContent.slice(-MAX_LOG_CHARS);
+  }
+  logConsole.scrollTop = logConsole.scrollHeight;
+}
+
+async function refreshStatus() {
+  try {
+    currentStatus = await api.getStatus();
+  } catch {
+    currentStatus = 'UNKNOWN';
+  }
+}
+
+api.onLogChunk((chunk) => appendLog(chunk));
+api.onRefreshStatus(() => {
+  void refreshStatus();
+});
+
+void (async () => {
+  await refreshStatus();
+  logConsole.textContent = '';
+  try {
+    const r = await api.startLogWatch();
+    devHint.textContent = `Logs ao vivo · ${r.path}`;
+  } catch (err) {
+    appendLog(`(falha ao observar log: ${err instanceof Error ? err.message : String(err)})\n`);
+  }
+})();
+
+copyDiagBtn.addEventListener('click', async () => {
+  copyDiagBtn.disabled = true;
+  try {
+    const { text } = await api.getDiagnostic({
+      status: currentStatus,
+      note: bugNoteInput.value,
+    });
+    await navigator.clipboard.writeText(text);
+    devHint.textContent = 'Diagnóstico copiado para a área de transferência.';
+  } catch (err) {
+    devHint.textContent = err instanceof Error ? err.message : String(err);
+  } finally {
+    copyDiagBtn.disabled = false;
+  }
+});
+
+reportBugBtn.addEventListener('click', async () => {
+  reportBugBtn.disabled = true;
+  devHint.textContent = 'Enviando relato...';
+  try {
+    const r = await api.openBugReport({
+      status: currentStatus,
+      note: bugNoteInput.value,
+      title: `[GUI] ${currentStatus} — relato`,
+    });
+    if (r.via === 'api') {
+      devHint.textContent = r.issueNumber
+        ? `Issue #${r.issueNumber} criada pela API.`
+        : 'Issue criada pela API.';
+    } else if (r.apiError) {
+      devHint.textContent = `API falhou (${r.apiError}). Abri o formulário do GitHub; diagnóstico no clipboard.`;
+    } else if (r.truncated) {
+      devHint.textContent =
+        'Issue aberta (corpo truncado). Diagnóstico completo no clipboard.';
+    } else {
+      devHint.textContent =
+        'Formulário do GitHub aberto (labels bug,gui). Diagnóstico no clipboard.';
+    }
+  } catch (err) {
+    devHint.textContent = err instanceof Error ? err.message : String(err);
+  } finally {
+    reportBugBtn.disabled = false;
+  }
+});
+
+openLogFolderBtn.addEventListener('click', async () => {
+  try {
+    const dir = await api.openLogFolder();
+    devHint.textContent = `Pasta: ${dir}`;
+  } catch (err) {
+    devHint.textContent = err instanceof Error ? err.message : String(err);
+  }
+});

--- a/golive-gui/src/main.ts
+++ b/golive-gui/src/main.ts
@@ -15,6 +15,38 @@ declare global {
       setNetMode: (mode: string) => Promise<string>;
       getTorStatus: () => Promise<{ presente: boolean; ativo: boolean; porta: number }>;
       installTor: () => Promise<{ ok: boolean; porta?: number; error?: string }>;
+      testProxy: (proxy: string) => Promise<{
+        ok: boolean;
+        ms?: number;
+        host?: string;
+        port?: number;
+        country?: string;
+        error?: string;
+      }>;
+      startLogWatch: () => Promise<{ path: string }>;
+      stopLogWatch: () => Promise<boolean>;
+      getDiagnostic: (payload: { status: string; note?: string }) => Promise<{
+        text: string;
+        logPath: string;
+        apiConfigured?: boolean;
+      }>;
+      openBugReport: (payload: {
+        status: string;
+        note?: string;
+        title?: string;
+      }) => Promise<{
+        ok: boolean;
+        via?: "api" | "github";
+        url: string;
+        issueNumber?: number;
+        copied: boolean;
+        truncated: boolean;
+        apiError?: string;
+      }>;
+      openLogFolder: () => Promise<string>;
+      setDevLogWindow: (open: boolean) => Promise<boolean>;
+      onLogChunk: (callback: (chunk: string) => void) => void;
+      onDevLogWindowClosed: (callback: () => void) => void;
       onRefreshStartup: (callback: () => void) => void;
       onRefreshStatus: (callback: () => void) => void;
       resizeWindow: (height: number) => void;
@@ -125,11 +157,16 @@ themeBtn.addEventListener('click', () => {
 // O warning do bypass ativo faz o conteudo crescer; a janela e fixa, entao reportamos a altura
 // necessaria para o main process redimensionar e nada ficar cortado.
 function fitWindowToContent() {
-  const container = document.querySelector('.container');
-  if (!container) return;
-  // +1 px de folga: sem isto a ultima linha as vezes ficava cortada por causa do arredondamento.
-  const height = Math.ceil(container.getBoundingClientRect().height + 1);
-  window.api.resizeWindow(height);
+  // Espera o layout apos hidden/details: sem rAF a medicao ainda ve a altura antiga
+  // (Personalizado expandia e a janela nunca encolhia ao voltar para Tor/Gratuitas).
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const container = document.querySelector('.container') as HTMLElement | null;
+      if (!container) return;
+      const height = Math.ceil(container.getBoundingClientRect().height + 1);
+      window.api.resizeWindow(height);
+    });
+  });
 }
 
 async function updateStatus() {
@@ -278,6 +315,13 @@ function selectMode(mode: string) {
     btn.classList.toggle('seg-btn--active', checked);
   }
   manualProxyGroup.hidden = mode !== 'manual';
+  // O status do Tor so faz sentido no modo Tor; nos outros ele so confunde.
+  torStatusEl.hidden = mode !== 'tor';
+  // Fecha o guia VPS ao sair do Personalizado: se ficar aberto, a proxima visita ja nasce alta.
+  if (mode !== 'manual') {
+    const guide = manualProxyGroup.querySelector('details.vps-guide');
+    if (guide) (guide as HTMLDetailsElement).open = false;
+  }
   fitWindowToContent();
 }
 
@@ -354,9 +398,90 @@ for (const btn of segBtns) {
   });
 }
 
+const proxyTestBtn = document.getElementById('proxyTestBtn') as HTMLButtonElement;
+const proxyTestStatus = document.getElementById('proxyTestStatus') as HTMLElement;
+
+proxyTestBtn.addEventListener('click', async () => {
+  const proxy = proxyInput.value.trim();
+  proxyTestBtn.disabled = true;
+  proxyTestStatus.classList.remove('proxy-test-status--ok', 'proxy-test-status--bad');
+  proxyTestStatus.textContent = 'Testando túnel até o gateway...';
+  fitWindowToContent();
+
+  try {
+    const r = await window.api.testProxy(proxy);
+    if (r.ok) {
+      proxyTestStatus.classList.add('proxy-test-status--ok');
+      const geo = r.country ? ` · saída ${r.country}` : '';
+      proxyTestStatus.textContent = `OK — túnel em ${r.ms ?? '?'}ms (${r.host}:${r.port})${geo}`;
+    } else {
+      proxyTestStatus.classList.add('proxy-test-status--bad');
+      const geo = r.country ? ` [${r.country}]` : '';
+      proxyTestStatus.textContent = `${r.error ?? 'Falha no teste'}${geo}`;
+    }
+  } catch (err) {
+    proxyTestStatus.classList.add('proxy-test-status--bad');
+    proxyTestStatus.textContent = err instanceof Error ? err.message : String(err);
+  } finally {
+    proxyTestBtn.disabled = false;
+    fitWindowToContent();
+  }
+});
+
+const vpsGuide = document.querySelector('.vps-guide');
+if (vpsGuide) {
+  vpsGuide.addEventListener('toggle', () => fitWindowToContent());
+}
+
 startupToggle.addEventListener('change', async () => {
   await window.api.setStartup(startupToggle.checked);
 });
+
+// ---------------------------------------------------------------------------
+// Modo desenvolvedor: so o toggle aqui. Logs e report ficam numa janela aparte.
+// ---------------------------------------------------------------------------
+const DEV_KEY = 'golivebypass-dev-mode';
+const devModeToggle = document.getElementById('devModeToggle') as HTMLInputElement;
+const devModeHint = document.getElementById('devModeHint') as HTMLElement;
+
+async function setDevMode(on: boolean) {
+  try {
+    localStorage.setItem(DEV_KEY, on ? '1' : '0');
+  } catch {
+    /* ignore */
+  }
+  try {
+    await window.api.setDevLogWindow(on);
+  } catch (err) {
+    console.error(err);
+  }
+  devModeHint.hidden = !on;
+  fitWindowToContent();
+}
+
+devModeToggle.addEventListener('change', () => {
+  void setDevMode(devModeToggle.checked);
+});
+
+window.api.onDevLogWindowClosed?.(() => {
+  devModeToggle.checked = false;
+  devModeHint.hidden = true;
+  try {
+    localStorage.setItem(DEV_KEY, '0');
+  } catch {
+    /* ignore */
+  }
+  fitWindowToContent();
+});
+
+try {
+  if (localStorage.getItem(DEV_KEY) === '1') {
+    devModeToggle.checked = true;
+    void setDevMode(true);
+  }
+} catch {
+  /* ignore */
+}
 
 // A bandeja tambem tem esses controles; sem os avisos, os dois ficariam dessincronizados.
 window.api.onRefreshStartup(refreshStartup);

--- a/golive-gui/src/style.css
+++ b/golive-gui/src/style.css
@@ -756,6 +756,225 @@ html[data-theme='dark'] .float-field input:focus {
   color: var(--faint);
 }
 
+.proxy-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.proxy-test-btn {
+  align-self: flex-start;
+  padding: 7px 12px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease;
+}
+
+.proxy-test-btn:hover:not(:disabled) {
+  border-color: var(--ink-strong);
+  background: rgba(128, 128, 128, 0.08);
+}
+
+.proxy-test-btn:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.proxy-test-status {
+  font-size: 11px;
+  color: var(--faint);
+  min-height: 13px;
+  line-height: 1.35;
+}
+
+.proxy-test-status--ok { color: #2e9e5b; }
+.proxy-test-status--bad { color: #c44b4b; }
+
+.vps-guide {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: var(--r-sm);
+  border: 1px dashed var(--line-strong);
+  background: transparent;
+}
+
+.vps-guide summary {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ink-soft);
+  list-style: none;
+}
+
+.vps-guide summary::-webkit-details-marker {
+  display: none;
+}
+
+.vps-guide summary::before {
+  content: '+ ';
+  font-family: var(--mono);
+  opacity: 0.6;
+}
+
+.vps-guide[open] summary::before {
+  content: '− ';
+}
+
+.vps-guide ol {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  font-size: 11.5px;
+  color: var(--ink-soft);
+  line-height: 1.45;
+}
+
+.vps-guide li + li {
+  margin-top: 4px;
+}
+
+.vps-guide code {
+  font-family: var(--mono);
+  font-size: 10.5px;
+}
+
+.vps-note {
+  margin: 8px 0 2px;
+  font-size: 11px;
+  color: var(--faint);
+  line-height: 1.4;
+}
+
+/* ------------------------------------------------------------
+   Modo desenvolvedor — janela de logs separada
+   ------------------------------------------------------------ */
+/* [hidden] precisa vencer regras com display:block (ex.: .dev-mode-hint), senao o
+   atributo hidden nao esconde e a janela fica alta sem motivo. */
+[hidden] {
+  display: none !important;
+}
+
+.dev-mode-hint {
+  display: block;
+  margin-top: -4px;
+  font-size: 11px;
+  color: var(--faint);
+}
+
+.dev-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dev-btn {
+  padding: 6px 10px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease;
+}
+
+.dev-btn:hover:not(:disabled) {
+  border-color: var(--ink-strong);
+  background: rgba(128, 128, 128, 0.08);
+}
+
+.dev-btn:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.dev-note-label {
+  font-size: 11px;
+  color: var(--faint);
+}
+
+.dev-note {
+  width: 100%;
+  resize: vertical;
+  min-height: 48px;
+  max-height: 120px;
+  padding: 8px 10px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  outline: none;
+}
+
+.dev-note:focus {
+  border-color: var(--ink-strong);
+}
+
+.log-console {
+  flex: 1;
+  min-height: 180px;
+  overflow: auto;
+  padding: 8px 10px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line-strong);
+  background: #0c0c0f;
+  color: #c8ecd0;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+html[data-theme='light'] .log-console {
+  background: #1a1a1e;
+  color: #d2e8d6;
+}
+
+.dev-hint {
+  font-size: 10.5px;
+  color: var(--faint);
+}
+
+body.logs-window {
+  margin: 0;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.logs-shell {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 36px 16px 14px;
+}
+
+.logs-header h1 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.logs-sub {
+  margin: 2px 0 4px;
+  font-size: 11.5px;
+  color: var(--faint);
+}
+
 /* ------------------------------------------------------------
    Aviso — popover ligado ao botão redondo "!"
    ------------------------------------------------------------ */

--- a/golive-gui/vite.config.ts
+++ b/golive-gui/vite.config.ts
@@ -1,9 +1,18 @@
 import { defineConfig } from 'vite'
 import electron from 'vite-plugin-electron'
 import renderer from 'vite-plugin-electron-renderer'
+import path from 'path'
 
 export default defineConfig({
   base: './',
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        logs: path.resolve(__dirname, 'logs.html'),
+      },
+    },
+  },
   plugins: [
     electron([
       {


### PR DESCRIPTION
## Summary

Melhora a GUI Electron para diagnóstico, saída Personalizado (VPS) e estabilidade da janela — sem alongar a UI principal.

### 1. Modo desenvolvedor + janela de logs separada
- Toggle **Modo desenvolvedor** na janela principal (compacta)
- Com o toggle ligado, abre uma **janela ao lado** com:
  - logs ao vivo de `golivebypass.log`
  - campo de relato
  - **Reportar bug** / **Copiar diagnóstico** / **Pasta de logs**
- Fechar a janela de logs (X) ou desligar o toggle encerra o watch do arquivo

### 2. Reportar bug
- Monta diagnóstico (versão, OS, Electron, `routeMode`, proxy mascarada, Tor, trecho do log)
- **Se API configurada** (`bugReportApiUrl` + `bugReportToken` no `settings.json`, ou env `GOLIVE_BUG_API_URL` / `GOLIVE_BUG_API_TOKEN`): `POST /v1/reports` e abre a issue criada
- **Senão**: abre `github.com/bezumiya/GoLiveBypass/issues/new` com labels `bug,gui` + diagnóstico no clipboard (URL truncada se passar do limite)

### 3. Personalizado / VPS
- Hint do segmento: `VPS / proxy`
- Botão **Testar conexão** (SOCKS5 → túnel até `gateway.discord.gg`)
- Detecta **país de saída** (Cloudflare `/cdn-cgi/trace`, fallback `ipwho.is`)
- Recusa saída **BR** (túnel ok, mas inútil para o bypass)
- Guia colapsável de como montar VPS fora do Brasil

### 4. Janela que crescia e não encolhia
- CSS `[hidden] { display: none !important }` — o hint “Janela de logs…” ignorava `hidden`
- Resize com `setContentSize` (área cliente) em vez de `setSize` (janela externa + titleBarOverlay)
- `requestAnimationFrame` duplo após esconder o Personalizado, para medir a altura correta

### 5. API de bug reports
- Default de labels: `bug,gui` (`.env.example`, `config.go`, README)
- Documentação de integração com a GUI

> **Nota:** a correção de detecção do Discord com pasta `app-*` incompleta (Squirrel) está no PR #41 e **não** faz parte deste PR.

## Arquivos principais
- `golive-gui/electron/main.ts`, `preload.ts`
- `golive-gui/index.html`, `logs.html`, `src/main.ts`, `src/logs.ts`, `src/style.css`, `vite.config.ts`
- `api/.env.example`, `api/README.md`, `api/internal/config/config.go` (+ testes)

## Test plan
- [ ] Abrir a GUI: janela principal compacta (sem painel de logs embutido)
- [ ] Ligar **Modo desenvolvedor** → janela de logs abre ao lado; desligar / fechar X → some e o toggle volta
- [ ] Com bypass ativo, logs ao vivo aparecem no console da janela de diagnóstico
- [ ] **Copiar diagnóstico** coloca texto no clipboard (senhas mascaradas)
- [ ] **Reportar bug** sem API → abre o form do GitHub com `bug`/`gui` (criar label `gui` no repo se ainda não existir)
- [ ] Personalizado → Testar conexão: mostra RTT + país; proxy BR deve falhar com mensagem clara
- [ ] Alternar Tor ↔ Gratuitas ↔ Personalizado: janela **cresce e encolhe** de volta
- [ ] Abrir/fechar o guia VPS (`details`): altura acompanha
- [ ] `cd api && go test ./...`
- [ ] `cd golive-gui && npm run compile` (ou `build:win`)
