### PR TITLE
api: fail-fast no boot — conferir labels antes de subir

### DIFF
--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -27,7 +27,19 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseLevel(cfg.LogLevel)}))
 	slog.SetDefault(logger)
 
-	e := server.New(cfg, gh.New(cfg.GitHubToken, cfg.GitHubRepo), logger)
+	client := gh.New(cfg.GitHubToken, cfg.GitHubRepo)
+	// Fail-fast no boot: se as labels de ISSUE_LABELS nao existem no repo alvo (ex.:
+	// deploy novo com repo trocado), aborta com mensagem clara em vez de responder
+	// 422 no primeiro report real. Erro de auth/rede tambem falha o boot.
+	checkCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	err = client.VerifyLabels(checkCtx, cfg.Labels)
+	cancel()
+	if err != nil {
+		logger.Error("labels do repo alvo nao conferem — abortando (crie as labels antes de subir)", "err", err, "repo", cfg.GitHubRepo)
+		os.Exit(1)
+	}
+
+	e := server.New(cfg, client, logger)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api/internal/gh/github.go
+++ b/api/internal/gh/github.go
@@ -40,6 +40,55 @@ type Issue struct {
 	Labels []string `json:"labels,omitempty"`
 }
 
+// VerifyLabels confere no boot que cada label de ISSUE_LABELS existe no repo alvo.
+// Sem isso, o primeiro report real devolveria 422 do GitHub e o usuario acharia
+// que a API quebrou. Erro de auth/rede tambem falha: melhor abortar o boot do que
+// aceitar requests enquanto a criacao de issues esta garantidamente quebrada.
+func (c *Client) VerifyLabels(ctx context.Context, labels []string) error {
+	if len(labels) == 0 {
+		return nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/repos/"+c.repo+"/labels", nil)
+	if err != nil {
+		return fmt.Errorf("montando requisicao: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", apiAccept)
+	req.Header.Set("X-GitHub-Api-Version", apiVersion)
+	req.Header.Set("User-Agent", "GoLiveBypass-bugreport-api")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("conferindo labels no GitHub: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var got []struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(body, &got); err != nil {
+			return fmt.Errorf("decodificando labels (%s): %w", resp.Status, err)
+		}
+		have := make(map[string]bool, len(got))
+		for _, l := range got {
+			have[l.Name] = true
+		}
+		for _, want := range labels {
+			if !have[want] {
+				return fmt.Errorf("a label %q nao existe no repo %s — crie-a em Settings → Labels antes de subir", want, c.repo)
+			}
+		}
+		return nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("autenticacao no GitHub falhou (%s): %s", resp.Status, strings.TrimSpace(string(body)))
+	default:
+		return fmt.Errorf("GitHub respondeu %s ao conferir labels: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+}
+
 type IssueResult struct {
 	Number int    `json:"number"`
 	URL    string `json:"html_url"`

--- a/api/internal/gh/github_test.go
+++ b/api/internal/gh/github_test.go
@@ -102,3 +102,55 @@ func TestCreateIssueTimeout(t *testing.T) {
 		t.Fatal("esperava erro de timeout")
 	}
 }
+
+func TestVerifyLabelsOK(t *testing.T) {
+	c, getReq := newFake(t, http.StatusOK,
+		`[{"name":"bug"},{"name":"gui"},{"name":"enhancement"}]`)
+
+	if err := c.VerifyLabels(context.Background(), []string{"bug", "gui"}); err != nil {
+		t.Fatalf("VerifyLabels() error = %v", err)
+	}
+	req, _ := getReq()
+	if req.Method != http.MethodGet {
+		t.Errorf("method = %s, want GET", req.Method)
+	}
+	if req.URL.Path != "/repos/owner/repo/labels" {
+		t.Errorf("path = %s", req.URL.Path)
+	}
+}
+
+func TestVerifyLabelsMissingOne(t *testing.T) {
+	c, _ := newFake(t, http.StatusOK, `[{"name":"bug"}]`)
+
+	err := c.VerifyLabels(context.Background(), []string{"bug", "gui"})
+	if err == nil || !strings.Contains(err.Error(), `"gui"`) {
+		t.Fatalf("err = %v, queria erro apontando a label gui", err)
+	}
+}
+
+func TestVerifyLabelsEmptyIsNoop(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New("tok", "owner/repo")
+	c.baseURL = srv.URL
+
+	if err := c.VerifyLabels(context.Background(), nil); err != nil {
+		t.Fatalf("VerifyLabels() error = %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("nenhuma requisicao deveria acontecer com labels vazias; houve %d", calls)
+	}
+}
+
+func TestVerifyLabelsAuthError(t *testing.T) {
+	c, _ := newFake(t, http.StatusUnauthorized, `{"message":"Bad credentials"}`)
+
+	err := c.VerifyLabels(context.Background(), []string{"bug"})
+	if err == nil || !strings.Contains(err.Error(), "autenticacao") {
+		t.Fatalf("err = %v, queria erro de autenticacao", err)
+	}
+}


### PR DESCRIPTION
## Problema

Deploy da API de bug reports no servidor principal com repo alvo trocado (ou label ausente — a `gui` não existia no `bezumiya/GoLiveBypass` até hoje) subia com `/healthz` **verde** e só falhava no **primeiro report real**, com 422 do GitHub ("labels não existem"). O usuário reportava bug e nada acontecia, achando que a API quebrou.

## Correção

- `gh.Client.VerifyLabels`: no boot, `GET /repos/{repo}/labels` e confere que cada label de `ISSUE_LABELS` existe no repo alvo
- Erro de auth/rede também aborta — melhor não aceitar requests enquanto a criação de issues está garantidamente quebrada
- `main.go`: verificação no boot com timeout de 15s; falha ⇒ `exit 1` com mensagem apontando o que criar

## Testes

- `go vet` + `go test ./...` verdes (novos: OK, label ausente, labels vazias=noop, erro de auth)
- Boot real contra o GitHub (`beluga/GoLiveBypass`): sobe com labels existentes
- Boot real com `ISSUE_LABELS="bug,label-que-nao-existe"`: aborta com exit 1 e mensagem clara

Label `gui` já foi criada no `bezumiya/GoLiveBypass` como parte do ajuste de produção.