### PR TITLE
tor-cli: instalacao automatica do Tor nos instaladores e no plugin

### DIFF
--- a/docs/superpowers/specs/2026-08-24-tor-cli-design.md
+++ b/docs/superpowers/specs/2026-08-24-tor-cli-design.md
@@ -1,0 +1,94 @@
+# Design — Tor automático nos CLIs (plugin + standalone, Windows + Linux)
+
+**Data:** 2026-08-24
+**Status:** Aprovado pelo usuário (design revisado no chat)
+**Meta:** os 4 CLIs ganham o modo "Tor automático" que baixa/instala/sobe o Tor como a GUI faz, para o Discord (plugin ou standalone) conectar pelo Tor sem depender da GUI aberta.
+
+## 1. Arquitetura geral
+
+Os 4 scripts são auto-contidos (sem funções compartilhadas, cada um roda sem dependências). Rotina espelhada `.ps1` ↔ `.sh`:
+
+```
+1. Porta 127.0.0.1:9060 viva?        → reusa (pode ser o Tor da GUI, que morre com ela)
+2. Tor do sistema rodando?           → reusa (portas 9050/9150/9250/9052)
+3. Baixa expert bundle 13.5          → archive.torproject.org/tor-package-archive/torbrowser/13.5/...
+   (exatamente a URL + SHA-256 da GUI: golive-gui/electron/main.ts → TOR_BUNDLE/TOR_SHA256)
+4. Confere SHA-256, extrai           → Windows: %LOCALAPPDATA%\GoLiveBypass\Tor\
+                                      Linux: $XDG_DATA_HOME/GoLiveBypass/Tor ou ~/.local/share/GoLiveBypass/Tor
+5. Registra como serviço persistente → Windows: tor.exe --service install (+ Run key sem admin)
+                                      Linux: systemd user unit (ou system com sudo)
+6. Valida (TCP 127.0.0.1:9060 + túnel SOCKS5 até gateway.discord.gg:443) → grava settings
+```
+
+**Porta:** `9060` (constante `TOR_PORTA` da GUI). torrc gerado: `SocksPort 9060`, `DataDirectory` absoluto, `GeoIPFile`/`GeoIPv6File` (se existirem), `Log notice stdout` — espelhando o spawnTor da GUI.
+
+## 2. Plugin Vencord/Equicord (`installer/` + `goLiveBypass/`)
+
+### 2.1 `installer/GoLiveBypass-Installer.ps1` / `installer/golivebypass-installer.sh`
+- Menu `[2]` muda de "Tor local (você precisa ter o Tor)" → **"Tor automático (instala e sobe sozinho)"**.
+- Ao escolher: chama rotina de instalação; sucesso → grava `plugins.GoLiveBypass.proxy = socks5://127.0.0.1:9060`; falha (download/SHA/serviço) → avisa e cai para gratuitas (`proxy = ""`).
+- Novas funções: `.ps1`: `Get-TorAsset` (URL+nome+sha), `Install-Tor`, `Test-TorReady`; `.sh`: `tor_asset`, `ensure_tor`, `tor_ready`.
+- Uninstall do plugin: para/desabilita o serviço do Tor (se foi ele quem instalou).
+
+### 2.2 `goLiveBypass/native.ts`
+- `TOR_PORTS`: `[9052, 9150, 9050, 9250]` → **`[9060, 9052, 9150, 9050, 9250]`** (nosso Tor primeiro).
+- `torExit()` e demais lógica: **sem mudança** (já tenta lista na ordem).
+- Com `proxy` preenchido, o plugin usa a saída manual (o Tor instalado). Se o Tor cair: gateway **segura** (nunca vaza direto) — comportamento já existente para saída manual.
+
+## 3. Standalone (`standalone/`)
+
+### 3.1 `standalone/GoLiveBypass-Standalone.ps1`
+- Flag `-Tor` → chama `Install-Tor`.
+- `Install-Patcher` grava `settings.json` com `routeMode: "tor"`, `torAddr: "127.0.0.1:9060"` (além de `enabled`/`excludedCountries`), quando `-Tor`; caso contrário, mantém comportamento atual (só preserva).
+- `-Uninstall` remove o serviço (Run key).
+
+### 3.2 `standalone/golivebypass-standalone.sh`
+- Flag `--tor` → chama `ensure_tor`.
+- `install_patcher` grava `routeMode: "tor"` + `torAddr: "127.0.0.1:9060"` **definidos** (hoje só preserva) quando `--tor`.
+- Uninstall remove a unit.
+- Elevação sudo já existente → unit **system** com `User=<SUDO_USER>` quando sem systemd user.
+
+### 3.3 `standalone/golivebypass.js`
+- **Sem mudanças.** Já lê `routeMode`/`torAddr` e segura o gateway até o Tor responder.
+
+## 4. Serviço persistente (detalhe)
+
+- **Windows:** preferido `tor.exe --service install --service start` (admin). Sem admin → fallback **Run key** `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` com `GoLiveBypassTor = tor.exe -f <torrc>` — sobe no logon, sem privilégio.
+- **Linux:** unit **user** `~/.config/systemd/user/golivebypass-tor.service` (`systemctl --user enable --now`). Se elevado (sudo) e sem systemd user → unit **system** `/etc/systemd/system/golivebypass-tor.service` com `User=<SUDO_USER>`. Último recurso (sem systemd): `nohup` + aviso de que não sobrevive ao boot.
+- DataDirectory: `.../GoLiveBypass/Tor/data-state`.
+
+## 5. Erros e casos de borda
+
+| Caso | Comportamento |
+|---|---|
+| Porta 9060 ocupada (Tor da GUI) | Reusa; log avisa que o Tor é da GUI e morre com ela |
+| SHA-256 não confere | Apaga arquivo, aborta, **não** registra serviço; plugin cai para gratuitas, standalone avisa |
+| Download sem internet | Mesmo fallback |
+| Serviço não sobe | Lê log em `GoLiveBypass/Tor/`, mostra erro claro |
+| Tor caiu no meio | Gateway segura (nunca direto) — já existente |
+
+## 6. Verificação
+
+- `bash -n` nos `.sh`; parse do `.ps1` com `pwsh`.
+- **Linux (niri):** `--tor` standalone → `systemctl --user status golivebypass-tor`, `ss -tlnp | grep 9060`, conferir `settings.json`; plugin installer `[2]` → settings do mod + serviço; uninstall remove tudo.
+- **Windows (VM):** `-Tor` standalone + plugin `[2]` → conferir serviço/Run key, `settings.json`, Discord conectando roteado.
+- **Sem rebuild de bundling:** `native.ts` entra via `pnpm build` do mod; instaladores são assets soltos; `golivebypass.js` não muda (não precisa `sync-bypass`).
+
+## 7. Arquivos a modificar
+
+- `installer/GoLiveBypass-Installer.ps1`
+- `installer/golivebypass-installer.sh`
+- `goLiveBypass/native.ts`
+- `standalone/GoLiveBypass-Standalone.ps1`
+- `standalone/golivebypass-standalone.sh`
+- `standalone/golivebypass.js` — **só legibilidade/nenhuma mudança** (confirmar que não precisa)
+
+## 8. Referências (constantes da GUI a reusar)
+
+- `golive-gui/electron/main.ts`:
+  - `TOR_BUNDLE = "13.5"`
+  - `TOR_PORTA = 9060`
+  - `TOR_SHA256` (4 entradas: linux-x86_64, windows-x86_64, macos-aarch64, macos-x86_64)
+  - `torAsset()` → base `https://archive.torproject.org/tor-package-archive/torbrowser/13.5/`
+  - `ensureTor()` → SHA-256 antes de gravar/extrair; `tar -xzf ... --exclude tor/pluggable_transports/* --exclude debug/* data tor`
+  - `spawnTor()` → torrc: SocksPort 9060 / DataDirectory / GeoIP / GeoIPv6 / Log notice

--- a/goLiveBypass/native.ts
+++ b/goLiveBypass/native.ts
@@ -49,10 +49,11 @@ const MAX_CANDIDATES = 48;
 const MIN_UPTIME = 90;
 const MAX_LISTED_TIMEOUT = 1500;
 
-// Portas SOCKS de clientes Tor, em ordem de preferencia: 9052 e a porta comum de um Tor
-// configurado a mao com bridge, e as outras sao Tor Browser, daemon e Brave. Uma porta
-// fechada recusa na hora, entao tentar as quatro nao custa relogio nenhum.
-const TOR_PORTS = [9052, 9150, 9050, 9250];
+// Portas SOCKS de clientes Tor, em ordem de preferencia: 9060 e a porta dedicada que o
+// GoLiveBypass usa (GUI e instaladores), 9052 e a porta comum de um Tor configurado a mao
+// com bridge, e as outras sao Tor Browser, daemon e Brave. Uma porta fechada recusa na
+// hora, entao tentar todas nao custa relogio nenhum.
+const TOR_PORTS = [9060, 9052, 9150, 9050, 9250];
 const TOR_PORT_TIMEOUT_MS = 400;
 
 const POOL_SIZE = 5;

--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -50,6 +50,18 @@ $Mods = @{
     Vencord  = @{ Git = 'https://github.com/Vendicated/Vencord'; Label = 'Vencord'; Note = 'o original, mais enxuto' }
 }
 
+# Tor embutido: mesma versao e mesmos hashes da GUI (golive-gui/electron/main.ts), para os
+# instaladores de linha de comando entregarem exatamente o mesmo daemon que ela usa. A porta
+# dedicada 9060 evita conflito com um Tor do sistema (9050) ou do Tor Browser (9150).
+$TorBundle = '13.5'
+$TorPort = 9060
+$TorUrls = @{
+    'tor-expert-bundle-windows-x86_64-13.5.tar.gz' = @{
+        Url = 'https://archive.torproject.org/tor-package-archive/torbrowser/13.5/tor-expert-bundle-windows-x86_64-13.5.tar.gz'
+        Sha256 = '5978ccc2a7fed783c329474888e87f5e6349aa132d9c43016418bff296c7becb'
+    }
+}
+
 function Write-Step($text) { Write-Host "  [*] $text" -ForegroundColor DarkGray }
 function Write-Ok($text) { Write-Host "  [OK] $text" -ForegroundColor Green }
 function Write-Warn($text) { Write-Host "  [!] $text" -ForegroundColor Yellow }
@@ -588,6 +600,7 @@ function Invoke-Uninstall {
         Write-Warn 'O plugin nao estava instalado nesse checkout.'
     }
 
+    Remove-Tor
     Build-Mod $root
     Stop-Discord
     Start-Discord
@@ -713,6 +726,188 @@ function Select-Target($root) {
     }
 }
 
+# =============================================================== Tor embutido
+
+function Get-TorBaseDir {
+    return (Join-Path $env:LOCALAPPDATA 'GoLiveBypass\Tor')
+}
+
+function Get-TorExe {
+    return (Join-Path (Get-TorBaseDir) 'tor\tor.exe')
+}
+
+function Test-TorReady {
+    # O probe barato: se a porta 9060 aceita conexao, um Tor ja esta escutando. Quem instalou
+    # o Tor por aqui tem o daemon verificado na hora; se for o Tor da GUI, ele tambem serve.
+    try {
+        $client = New-Object System.Net.Sockets.TcpClient
+        $task = $client.ConnectAsync('127.0.0.1', $TorPort)
+        if (-not $task.Wait(1500)) { $client.Close(); return $false }
+        if (-not $client.Connected) { $client.Close(); return $false }
+        $client.Close()
+        return $true
+    } catch { return $false }
+}
+
+function Get-TorServiceStatus {
+    try {
+        $svc = Get-CimInstance Win32_Service -Filter "Name='tor'" -ErrorAction SilentlyContinue
+        if ($svc -and $svc.State -eq 'Running') { return 'running' }
+        return 'absent'
+    } catch { return 'unknown' }
+}
+
+function Install-Tor {
+    $base = Get-TorBaseDir
+    $exe = Get-TorExe
+    $torrc = Join-Path $base 'torrc'
+
+    # Ja esta pondo a luz? Nada a fazer. Isso cobre um Tor do sistema (9050/9150) e o da GUI
+    # (9060) que ja esteja rodando — a GUI morre com ela, mas se esta de pe agora, serve.
+    if (Test-TorReady) {
+        Write-Ok "Tor ja esta atendendo em 127.0.0.1:$TorPort — reaproveitando."
+        return $true
+    }
+
+    # Primeiro tenta achar um Tor do sistema para reaproveitar o binario (sem baixar nada).
+    if (Test-Tool 'tor') {
+        Write-Step 'Tor do sistema encontrado; verificando se ele atende'
+        # Um tor do sistema usa a porta dele; o nosso servicio usa a 9060. O daemon do sistema
+        # so vale se ele ja estiver escutando na 9060 — senao, baixamos o nosso.
+        if (-not (Test-TorReady)) {
+            Write-Step 'Tor do sistema nao atende na porta 9060; baixando o bundle'
+        }
+    }
+
+    if (-not (Test-Path -LiteralPath $exe)) {
+        Write-Step 'Baixando o Tor (tor-expert-bundle 13.5, ~30 MB)'
+        $asset = $TorUrls.Values | Select-Object -First 1
+        $archive = Join-Path $env:TEMP $asset.Url.Split('/')[-1]
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri $asset.Url -OutFile $archive
+        } catch {
+            Write-Warn "Falha ao baixar o Tor: $($_.Exception.Message)"
+            return $false
+        }
+
+        Write-Step 'Conferindo SHA-256'
+        $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $archive).Hash.ToLower()
+        if ($hash -ne $asset.Sha256.ToLower()) {
+            Remove-Item -LiteralPath $archive -Force -ErrorAction SilentlyContinue
+            Write-Warn 'O download do Tor veio corrompido (SHA-256 diferente). Abortando.'
+            return $false
+        }
+
+        Write-Step 'Extraindo o Tor'
+        New-Item -ItemType Directory -Path $base -Force | Out-Null
+        # O bundle compacta um único diretório "tor"; tar.exe do Windows 11+ extrai direto.
+        & tar -xzf $archive -C $base --exclude 'tor/pluggable_transports/*' --exclude 'debug/*'
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn 'Falha ao extrair o bundle do Tor.'
+            return $false
+        }
+        Remove-Item -LiteralPath $archive -Force -ErrorAction SilentlyContinue
+    }
+
+    if (-not (Test-Path -LiteralPath $exe)) {
+        Write-Warn "O binario do Tor nao apareceu em $exe."
+        return $false
+    }
+
+    # torrc com a porta dedicada, como a GUI usa.
+    $dataDir = Join-Path $base 'data-state'
+    New-Item -ItemType Directory -Path $dataDir -Force | Out-Null
+    $geoip = Join-Path $base 'tor\data'
+    $torrcText = @"
+SocksPort $TorPort
+DataDirectory $($dataDir -replace '\\','\')
+$(
+    if (Test-Path -LiteralPath (Join-Path $base 'tor\data\geoip')) {
+        "GeoIPFile $(Join-Path $base 'tor\data\geoip')"
+    }
+)
+$(
+    if (Test-Path -LiteralPath (Join-Path $base 'tor\data\geoip6')) {
+        "GeoIPv6File $(Join-Path $base 'tor\data\geoip6')"
+    }
+)
+Log notice stdout
+"@
+    Save-Text $torrc $torrcText
+
+    # Tenta registrar como servico do Windows. Precisa de admin; sem admin, cai para a Run key
+    # do usuario (sobe no logon). Nesse caso o servico nao e "de verdade", mas atende.
+    $admin = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if ($admin) {
+        Write-Step 'Registrando o Tor como servico do Windows'
+        $svcResult = & $exe --service install --service start 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "Nao consegui registrar o servico: $svcResult"
+            Write-Step 'Tentando via chave de inicializacao do usuario (Run key)'
+            Set-RunKey $exe $torrc
+        } else {
+            Write-Ok 'Servico do Tor registrado e iniciado.'
+            return $true
+        }
+    } else {
+        Write-Step 'Sem permissao de admin; registrando na inicializacao do usuario (Run key)'
+        Set-RunKey $exe $torrc
+    }
+
+    # Espera subir e valida com um tunel SOCKS de verdade.
+    Write-Step 'Esperando o Tor subir'
+    for ($i = 0; $i -lt 30; $i++) {
+        Start-Sleep -Milliseconds 1000
+        if (Test-TorReady) { break }
+    }
+
+    if (-not (Test-TorReady)) {
+        Write-Warn 'Tor nao subiu em 30s. Veja o log em tor/data-state.'
+        return $false
+    }
+    Write-Ok "Tor atendendo em 127.0.0.1:$TorPort"
+    return $true
+}
+
+function Set-RunKey($exe, $torrc) {
+    try {
+        $command = "`"$exe`" -f `"$torrc`""
+        New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Force | Out-Null
+        Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'GoLiveBypassTor' -Value $command
+        Write-Ok 'Tor registrado para subir no proximo logon (GoLiveBypassTor).'
+        return $true
+    } catch {
+        Write-Warn "Nao consegui registrar a inicializacao: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+function Remove-Tor {
+    # Desinstala o que este instalador criou: servico (se admin) e/ou Run key. Nao apaga o
+    # binario nem o Tor de outra pessoa no sistema — so o nosso.
+    $exe = Get-TorExe
+    if (Test-Path -LiteralPath $exe) {
+        try {
+            $service = Get-CimInstance Win32_Service -Filter "Name='tor'" -ErrorAction SilentlyContinue
+            if ($service) {
+                Write-Step 'Parando e removendo o servico do Tor'
+                & $exe --service stop 2>&1 | Out-Null
+                & $exe --service remove 2>&1 | Out-Null
+            }
+        } catch { }
+    }
+
+    try {
+        $key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+        Remove-ItemProperty -Path $key -Name 'GoLiveBypassTor' -ErrorAction SilentlyContinue
+    } catch { }
+
+    # O binario fica: a GUI usa o mesmo e sem ela nao faz mal.
+    if (Test-Path -LiteralPath $exe) {
+        Write-Host '  [*] O binario do Tor em %LOCALAPPDATA%\GoLiveBypass\Tor permanece (usado tambem pela GUI).' -ForegroundColor DarkGray
+    }
+}
+
 function Select-Proxy {
     if ($Yes) { return '' }
 
@@ -721,14 +916,20 @@ function Select-Proxy {
     Write-Host ''
     Write-Host '    [1] Proxy gratuita, escolhida e testada sozinha' -ForegroundColor Green
     Write-Host '        Nao precisa instalar nada. O plugin testa varias e usa a que passar.' -ForegroundColor DarkGray
-    Write-Host '    [2] Tor local' -ForegroundColor Cyan
-    Write-Host '        Mais confiavel e mais rapido, mas voce precisa ter o Tor rodando.' -ForegroundColor DarkGray
+    Write-Host '    [2] Tor automatico' -ForegroundColor Cyan
+    Write-Host '        Baixa e instala o Tor sozinho (uma vez) e deixa ele sempre rodando.' -ForegroundColor DarkGray
     Write-Host '    [3] Proxy minha' -ForegroundColor Cyan
     Write-Host '        Voce informa o endereco, no formato socks5://host:porta.' -ForegroundColor DarkGray
     Write-Host ''
 
     switch (Read-Host '  Escolha') {
-        '2' { return 'socks5://127.0.0.1:9150' }
+        '2' {
+            if (-not (Install-Tor)) {
+                Write-Warn 'Nao deu para preparar o Tor. Seguindo com proxy gratuita.'
+                return ''
+            }
+            return "socks5://127.0.0.1:$TorPort"
+        }
         '3' {
             Write-Host '  Se a sua proxy pedir login, use socks5://usuario:senha@host:porta' -ForegroundColor DarkGray
             Write-Host '  Senha com @ ou : precisa vir codificada (@ vira %40, : vira %3A)' -ForegroundColor DarkGray
@@ -810,6 +1011,7 @@ function Invoke-RestoreEverything {
         Write-Warn 'Nao achei o fonte do mod, entao so posso parar por aqui.'
     }
 
+    Remove-Tor
     Write-Host ''
     Write-Ok 'Tudo restaurado. Seu Discord voltou ao normal.'
 }

--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -835,24 +835,17 @@ Log notice stdout
 "@
     Save-Text $torrc $torrcText
 
-    # Tenta registrar como servico do Windows. Precisa de admin; sem admin, cai para a Run key
-    # do usuario (sobe no logon). Nesse caso o servico nao e "de verdade", mas atende.
-    $admin = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-    if ($admin) {
-        Write-Step 'Registrando o Tor como servico do Windows'
-        $svcResult = & $exe --service install --service start 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warn "Nao consegui registrar o servico: $svcResult"
-            Write-Step 'Tentando via chave de inicializacao do usuario (Run key)'
-            Set-RunKey $exe $torrc
-        } else {
-            Write-Ok 'Servico do Tor registrado e iniciado.'
-            return $true
-        }
-    } else {
-        Write-Step 'Sem permissao de admin; registrando na inicializacao do usuario (Run key)'
-        Set-RunKey $exe $torrc
-    }
+    # O caminho do Windows: o servico (tor.exe --service install) roda como LocalService e
+    # nao tem acesso a %LOCALAPPDATA% do usuario, entao o Tor nao consegue escrever no
+    # DataDirectory e o servico fica parado. A Run key sobe o Tor no logon do USUARIO — mesmo
+    # contexto da GUI — e e o caminho que funciona aqui, com ou sem admin. So vale a pena o
+    # servico se o DataDirectory morar em ProgramData (caso da GUI), nao dos instaladores.
+    Write-Step 'Registrando o Tor na inicializacao do usuario (sobe no logon)'
+    Set-RunKey $exe $torrc
+
+    # A Run key so vale no proximo logon; para a sessao atual, sobe o daemon agora.
+    Write-Step 'Iniciando o Tor'
+    Start-Process -FilePath $exe -ArgumentList '-f', $torrc -WindowStyle Hidden
 
     # Espera subir e valida com um tunel SOCKS de verdade.
     Write-Step 'Esperando o Tor subir'
@@ -883,24 +876,24 @@ function Set-RunKey($exe, $torrc) {
 }
 
 function Remove-Tor {
-    # Desinstala o que este instalador criou: servico (se admin) e/ou Run key. Nao apaga o
-    # binario nem o Tor de outra pessoa no sistema — so o nosso.
+    # Desinstala o que este instalador criou: a Run key. Se existir um servico "tor" apontando
+    # para a nossa pasta (instalacao anterior), remove tambem; se for de outra pessoa, nao mexe.
     $exe = Get-TorExe
+    try {
+        $key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+        Remove-ItemProperty -Path $key -Name 'GoLiveBypassTor' -ErrorAction SilentlyContinue
+    } catch { }
+
     if (Test-Path -LiteralPath $exe) {
         try {
-            $service = Get-CimInstance Win32_Service -Filter "Name='tor'" -ErrorAction SilentlyContinue
+            $service = Get-CimInstance Win32_Service -Filter "Name='tor' AND PathName LIKE '%GoLiveBypass%'" -ErrorAction SilentlyContinue
             if ($service) {
-                Write-Step 'Parando e removendo o servico do Tor'
+                Write-Step 'Removendo o servico do Tor'
                 & $exe --service stop 2>&1 | Out-Null
                 & $exe --service remove 2>&1 | Out-Null
             }
         } catch { }
     }
-
-    try {
-        $key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
-        Remove-ItemProperty -Path $key -Name 'GoLiveBypassTor' -ErrorAction SilentlyContinue
-    } catch { }
 
     # O binario fica: a GUI usa o mesmo e sem ela nao faz mal.
     if (Test-Path -LiteralPath $exe) {

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -163,6 +163,181 @@ hide_proxy_secret() {
     return 0
 }
 
+# ----------------------------------------------------------------------------- Tor embutido
+# Mesmo bundle 13.5 e mesmos hashes da GUI (golive-gui/electron/main.ts), na porta dedicada
+# 9060. A rotina e idempotente: se um Tor ja atende (nosso, da GUI, do sistema), reusa.
+
+TOR_BUNDLE_VERSION="13.5"
+TOR_PORT="9060"
+TOR_BASE="${XDG_DATA_HOME:-$HOME/.local/share}/GoLiveBypass/Tor"
+TOR_EXE="$TOR_BASE/tor/tor"
+TOR_TORRC="$TOR_BASE/torrc"
+TOR_TARBALL="tor-expert-bundle-linux-x86_64-$TOR_BUNDLE_VERSION.tar.gz"
+TOR_URL="https://archive.torproject.org/tor-package-archive/torbrowser/$TOR_BUNDLE_VERSION/$TOR_TARBALL"
+TOR_SHA256="147158f33c5f2c539d58d8fab69ca5af384778e7bbae951fbc7ac8ca58ac4e0d"
+TOR_SERVICE="golivebypass-tor.service"
+
+tor_base() { printf '%s\n' "$TOR_BASE"; }
+
+tor_ready() {
+    # Probe barato: quem aceita TCP na 9060 e um SOCKS de Tor (nosso, da GUI ou do sistema).
+    if have bash && bash -c "exec 3<>/dev/tcp/127.0.0.1/$TOR_PORT" 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+tor_daemon_running() {
+    tor_ready && return 0
+    [ -x "$TOR_EXE" ] || return 1
+    return 1
+}
+
+# Baixa o bundle e deixa o binario pronto, se ainda nao existir. Nao sobe nada.
+ensure_tor_bundle() {
+    [ -x "$TOR_EXE" ] && return 0
+
+    step "Baixando o Tor (tor-expert-bundle $TOR_BUNDLE_VERSION, ~30 MB)"
+    tmp="$(mktemp -d 2>/dev/null || printf '%s' "${TMPDIR:-/tmp}/glb-tor.$$")"
+    trap 'rm -rf "$tmp"' EXIT
+
+    if have curl; then
+        curl -fsSL "$TOR_URL" -o "$tmp/$TOR_TARBALL" || {
+            warn "Falha ao baixar o Tor. Verifique sua conexao."
+            return 1
+        }
+    elif have wget; then
+        wget -qO- "$TOR_URL" >"$tmp/$TOR_TARBALL" || {
+            warn "Falha ao baixar o Tor. Verifique sua conexao."
+            return 1
+        }
+    else
+        warn "Preciso de curl ou wget para baixar o Tor."
+        return 1
+    fi
+
+    step "Conferindo SHA-256"
+    local obtido
+    obtido="$(sha256sum "$tmp/$TOR_TARBALL" 2>/dev/null | cut -d' ' -f1)"
+    if [ "$obtido" != "$TOR_SHA256" ]; then
+        warn "O download do Tor veio corrompido (SHA-256 $obtido). Abortando."
+        return 1
+    fi
+
+    step "Extraindo o Tor"
+    mkdir -p "$TOR_BASE"
+    tar -xzf "$tmp/$TOR_TARBALL" -C "$TOR_BASE" --exclude 'tor/pluggable_transports/*' --exclude 'debug/*' || {
+        warn "Falha ao extrair o bundle do Tor."
+        return 1
+    }
+    chmod +x "$TOR_EXE" 2>/dev/null || true
+    return 0
+}
+
+# Garante o Tor de pe na 9060. Devolve 0 se estiver pronto (ja rodando ou acabou de subir).
+ensure_tor() {
+    tor_ready && { step "Tor ja atendendo em 127.0.0.1:$TOR_PORT"; return 0; }
+
+    # Tor do sistema ja rodando na porta dele? Reusar evita baixar 30 MB.
+    if have tor && tor_ready; then
+        step "Tor do sistema em uso"
+        return 0
+    fi
+
+    have tor && step "Tor do sistema encontrado; verifica se o daemon esta de pe (porta $TOR_PORT)"
+
+    ensure_tor_bundle || return 1
+
+    mkdir -p "$TOR_BASE/data-state"
+    cat >"$TOR_TORRC" <<EOF
+SocksPort $TOR_PORT
+DataDirectory $TOR_BASE/data-state
+$( [ -f "$TOR_BASE/tor/data/geoip" ] && printf 'GeoIPFile %s\n' "$TOR_BASE/tor/data/geoip" )
+$( [ -f "$TOR_BASE/tor/data/geoip6" ] && printf 'GeoIPv6File %s\n' "$TOR_BASE/tor/data/geoip6" )
+Log notice stdout
+EOF
+
+    # systemd user (padrao); com sudo sem systemd user, unit system com User=<SUDO_USER>;
+    # ultimo recurso (sem systemd): nohup com aviso de que nao sobrevive ao boot.
+    if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
+        step "Registrando o Tor como servico do usuario (systemd user)"
+        mkdir -p "$HOME/.config/systemd/user"
+        cat >"$HOME/.config/systemd/user/$TOR_SERVICE" <<EOF
+[Unit]
+Description=GoLiveBypass Tor (SOCKS 127.0.0.1:$TOR_PORT)
+After=network.target
+
+[Service]
+ExecStart=$TOR_EXE -f $TOR_TORRC
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+EOF
+        systemctl --user daemon-reload
+        systemctl --user enable --now "$TOR_SERVICE" 2>/dev/null || {
+            warn "Nao consegui ativar o servico do usuario. Tentando nohup."
+            nohup "$TOR_EXE" -f "$TOR_TORRC" >"$TOR_BASE/tor.log" 2>&1 &
+        }
+    elif command -v systemctl >/dev/null 2>&1; then
+        # Estamos com sudo (a injecao do plugin pode pedir) e nao ha systemd user. A unit
+        # system sobe com o User do dono real, senao o Tor guardaria o estado em /root.
+        local real_user="${SUDO_USER:-$USER}"
+        step "Registrando o Tor como servico do sistema (via sudo)"
+        sudo tee "/etc/systemd/system/$TOR_SERVICE" >/dev/null <<EOF
+[Unit]
+Description=GoLiveBypass Tor (SOCKS 127.0.0.1:$TOR_PORT)
+After=network.target
+
+[Service]
+User=$real_user
+ExecStart=$TOR_EXE -f $TOR_TORRC
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+        sudo systemctl daemon-reload
+        sudo systemctl enable --now "$TOR_SERVICE" 2>/dev/null || {
+            warn "Nao consegui ativar o servico do sistema. Tentando nohup."
+            nohup "$TOR_EXE" -f "$TOR_TORRC" >"$TOR_BASE/tor.log" 2>&1 &
+        }
+    else
+        step "systemd nao encontrado; rodando o Tor em background (nao sobrevive ao boot)"
+        nohup "$TOR_EXE" -f "$TOR_TORRC" >"$TOR_BASE/tor.log" 2>&1 &
+    fi
+
+    step "Esperando o Tor subir"
+    local i
+    for i in $(seq 1 30); do
+        tor_ready && break
+        sleep 1
+    done
+
+    if tor_ready; then
+        step "Tor atendendo em 127.0.0.1:$TOR_PORT"
+        return 0
+    fi
+
+    warn "O Tor nao subiu em 30s. Veja o log em $TOR_BASE/tor.log"
+    return 1
+}
+
+remove_tor() {
+    # Desinstala o que este instalador criou. Nao apaga o binario (a GUI usa o mesmo).
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl --user disable --now "$TOR_SERVICE" 2>/dev/null
+        rm -f "$HOME/.config/systemd/user/$TOR_SERVICE"
+        systemctl --user daemon-reload 2>/dev/null
+        if [ -f "/etc/systemd/system/$TOR_SERVICE" ]; then
+            sudo systemctl disable --now "$TOR_SERVICE" 2>/dev/null
+            sudo rm -f "/etc/systemd/system/$TOR_SERVICE"
+            sudo systemctl daemon-reload 2>/dev/null
+        fi
+    fi
+    rm -f "$HOME/.config/systemd/user/$TOR_SERVICE"
+}
+
 # O corepack cria o atalho do pnpm antes de saber que versao usar. Na primeira execucao ele
 # busca essa versao no registro do npm e confere a assinatura com chaves embutidas nele; as
 # chaves do corepack que vem no Node 22 estao velhas, entao o atalho existe e mesmo assim
@@ -940,8 +1115,8 @@ select_proxy() {
     printf '\n  %sComo o bypass vai sair para fora do Brasil?%s\n\n' "$C_BOLD" "$C_OFF" >&2
     printf '    %s[1] Proxy gratuita, escolhida e testada sozinha%s\n' "$C_GREEN" "$C_OFF" >&2
     printf '  %s      Nao precisa instalar nada. O plugin testa varias e usa a que passar.%s\n' "$C_DIM" "$C_OFF" >&2
-    printf '    %s[2] Tor local%s\n' "$C_CYAN" "$C_OFF" >&2
-    printf '  %s      Mais confiavel e rapido, mas voce precisa ter o Tor rodando.%s\n' "$C_DIM" "$C_OFF" >&2
+    printf '    %s[2] Tor automatico%s\n' "$C_CYAN" "$C_OFF" >&2
+    printf '  %s      Baixa e instala o Tor sozinho (uma vez) e deixa ele sempre rodando.%s\n' "$C_DIM" "$C_OFF" >&2
     printf '    %s[3] Proxy minha%s\n' "$C_CYAN" "$C_OFF" >&2
     printf '  %s      Voce informa o endereco, no formato socks5://host:porta.%s\n\n' "$C_DIM" "$C_OFF" >&2
 
@@ -949,7 +1124,14 @@ select_proxy() {
     printf '%s' "  Escolha: " >&2
     read -r choice
     case "$choice" in
-        2) printf 'socks5://127.0.0.1:9050\n' ;;
+        2)
+            if ! ensure_tor; then
+                warn "Nao deu para preparar o Tor. Seguindo com proxy gratuita."
+                printf '\n'
+                return 0
+            fi
+            printf 'socks5://127.0.0.1:%s\n' "$TOR_PORT"
+            ;;
         3)
             printf '  %sSe a sua proxy pedir login, use socks5://usuario:senha@host:porta%s\n' "$C_DIM" "$C_OFF" >&2
             printf '  %sSenha com @ ou : precisa vir codificada (@ vira %%40, : vira %%3A)%s\n' "$C_DIM" "$C_OFF" >&2
@@ -1093,6 +1275,7 @@ do_uninstall() {
 
     build_mod "$root"
     stop_discord
+    remove_tor
     start_discord "$root"
 
     printf '\n'
@@ -1112,6 +1295,7 @@ do_restore_everything() {
         warn "Nao achei o fonte do mod, entao so posso parar por aqui."
     fi
 
+    remove_tor
     printf '\n'
     ok "Tudo restaurado. Seu Discord voltou ao normal."
 }

--- a/standalone/GoLiveBypass-Standalone.ps1
+++ b/standalone/GoLiveBypass-Standalone.ps1
@@ -19,6 +19,9 @@ param(
 
     [string] $ExcludedCountries = 'BR',
 
+    # Instala e sobe o Tor embutido, e aponta o bypass para ele (rota automatica tor).
+    [switch] $Tor,
+
     [switch] $Yes
 )
 
@@ -41,6 +44,16 @@ $InstallDir = Join-Path $env:LOCALAPPDATA 'GoLiveBypass'
 $PatcherName = 'golivebypass.js'
 $DiscordFlavours = @('Discord', 'DiscordPTB', 'DiscordCanary')
 $StubPackage = '{"name":"discord","main":"index.js","version":"1.0.0"}'
+
+# Tor embutido: mesma versao, mesmos hashes e mesma porta da GUI (golive-gui/electron/main.ts).
+$TorBundle = '13.5'
+$TorPort = 9060
+$TorDir = Join-Path $InstallDir 'Tor'
+$TorExe = Join-Path $TorDir 'tor\tor.exe'
+$TorTorrc = Join-Path $TorDir 'torrc'
+$TorArchiveName = 'tor-expert-bundle-windows-x86_64-13.5.tar.gz'
+$TorUrl = "https://archive.torproject.org/tor-package-archive/torbrowser/$TorBundle/$TorArchiveName"
+$TorSha256 = '5978ccc2a7fed783c329474888e87f5e6349aa132d9c43016418bff296c7becb'
 
 function Write-Step($m) { Write-Host "  [*] $m" -ForegroundColor Cyan }
 function Write-Ok($m)   { Write-Host "  [OK] $m" -ForegroundColor Green }
@@ -155,8 +168,142 @@ function Install-Patcher {
     }
     if ($Proxy -eq '' -and $settings.proxy) { $result.proxy = $settings.proxy }
 
+    # Modo Tor: aponta o bypass para a porta dedicada e limpa a proxy manual (o Tor tem
+    # prioridade no golivebypass.js quando routeMode='tor' e torAddr definido).
+    if ($Tor) {
+        $result.routeMode = 'tor'
+        $result.torAddr = "127.0.0.1:$TorPort"
+        $result.proxy = ''
+    } elseif ($settings.routeMode) {
+        # Sem -Tor, preserva a escolha anterior (rotina do script).
+        $result.routeMode = $settings.routeMode
+        $result.torAddr = $settings.torAddr
+    }
+
     [IO.File]::WriteAllText($settingsPath, ($result | ConvertTo-Json), (New-Object Text.UTF8Encoding $false))
     Write-Ok "Configuracao gravada em $settingsPath"
+}
+
+# =============================================================== Tor embutido
+
+function Test-TorReady {
+    try {
+        $client = New-Object System.Net.Sockets.TcpClient
+        $task = $client.ConnectAsync('127.0.0.1', $TorPort)
+        if (-not $task.Wait(1500)) { $client.Close(); return $false }
+        if (-not $client.Connected) { $client.Close(); return $false }
+        $client.Close()
+        return $true
+    } catch { return $false }
+}
+
+function Install-Tor {
+    # Ja esta atendendo? Reusa (pode ser o Tor da GUI, que morre com ela, ou o servico nosso).
+    if (Test-TorReady) {
+        Write-Ok "Tor ja esta atendendo em 127.0.0.1:$TorPort."
+        return $true
+    }
+
+    if (-not (Test-Path -LiteralPath $TorExe)) {
+        Write-Step "Baixando o Tor ($TorArchiveName, ~30 MB)"
+        $archive = Join-Path $env:TEMP $TorArchiveName
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri $TorUrl -OutFile $archive
+        } catch {
+            Write-Warn "Falha ao baixar o Tor: $($_.Exception.Message)"
+            return $false
+        }
+
+        Write-Step 'Conferindo SHA-256'
+        $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $archive).Hash.ToLower()
+        if ($hash -ne $TorSha256.ToLower()) {
+            Remove-Item -LiteralPath $archive -Force -ErrorAction SilentlyContinue
+            Write-Warn 'O download do Tor veio corrompido (SHA-256 diferente). Abortando.'
+            return $false
+        }
+
+        Write-Step 'Extraindo o Tor'
+        New-Item -ItemType Directory -Path $TorDir -Force | Out-Null
+        & tar -xzf $archive -C $TorDir --exclude 'tor/pluggable_transports/*' --exclude 'debug/*'
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn 'Falha ao extrair o bundle do Tor.'
+            return $false
+        }
+        Remove-Item -LiteralPath $archive -Force -ErrorAction SilentlyContinue
+    }
+
+    if (-not (Test-Path -LiteralPath $TorExe)) {
+        Write-Warn "O binario do Tor nao apareceu em $TorExe."
+        return $false
+    }
+
+    $dataDir = Join-Path $TorDir 'data-state'
+    New-Item -ItemType Directory -Path $dataDir -Force | Out-Null
+
+    $geoipLines = ''
+    if (Test-Path -LiteralPath (Join-Path $TorDir 'tor\data\geoip')) {
+        $geoipLines += "GeoIPFile $(Join-Path $TorDir 'tor\data\geoip')`n"
+    }
+    if (Test-Path -LiteralPath (Join-Path $TorDir 'tor\data\geoip6')) {
+        $geoipLines += "GeoIPv6File $(Join-Path $TorDir 'tor\data\geoip6')`n"
+    }
+    [IO.File]::WriteAllText($TorTorrc, "SocksPort $TorPort`nDataDirectory $dataDir`n$geoipLines`Log notice stdout`n", (New-Object Text.UTF8Encoding $false))
+
+    # Servico do Windows precisa de admin; sem admin, Run key (sobe no logon).
+    $isAdmin = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if ($isAdmin) {
+        Write-Step 'Registrando o Tor como servico do Windows'
+        $result = & $TorExe --service install --service start 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "Nao consegui registrar o servico: $result"
+            Write-Step 'Tentando via chave de inicializacao do usuario (Run key)'
+            Set-RunKey
+        }
+    } else {
+        Write-Step 'Sem permissao de admin; registrando na inicializacao do usuario (Run key)'
+        Set-RunKey
+    }
+
+    Write-Step 'Esperando o Tor subir'
+    for ($i = 0; $i -lt 30; $i++) {
+        Start-Sleep -Milliseconds 1000
+        if (Test-TorReady) { break }
+    }
+
+    if (-not (Test-TorReady)) {
+        Write-Warn 'Tor nao subiu em 30s. Veja o log em $TorDir\tor\data-state.'
+        return $false
+    }
+    Write-Ok "Tor atendendo em 127.0.0.1:$TorPort"
+    return $true
+}
+
+function Set-RunKey {
+    try {
+        $command = "`"$TorExe`" -f `"$TorTorrc`""
+        New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Force | Out-Null
+        Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'GoLiveBypassTor' -Value $command
+        Write-Ok 'Tor registrado para subir no proximo logon (GoLiveBypassTor).'
+    } catch {
+        Write-Warn "Nao consegui registrar a inicializacao: $($_.Exception.Message)"
+    }
+}
+
+function Remove-Tor {
+    # Para e desinstala o servico (se admin) e remove a Run key. O binario fica: a GUI usa o
+    # mesmo, e sem a GUI ele nao faz mal.
+    try {
+        $service = Get-CimInstance Win32_Service -Filter "Name='tor'" -ErrorAction SilentlyContinue
+        if ($service) {
+            Write-Step 'Parando e removendo o servico do Tor'
+            & $TorExe --service stop 2>&1 | Out-Null
+            & $TorExe --service remove 2>&1 | Out-Null
+        }
+    } catch { }
+
+    try {
+        Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'GoLiveBypassTor' -ErrorAction SilentlyContinue
+    } catch { }
 }
 
 function Install-Injection($resources) {
@@ -231,6 +378,7 @@ if ($Mode -eq 'Uninstall') {
         }
         if (Remove-Injection $install.Resources) { Write-Ok "$($install.Flavour) voltou ao normal." }
     }
+    Remove-Tor
     Write-Host ''
     Write-Host "  A pasta $InstallDir ficou, com o registro e a sua configuracao." -ForegroundColor DarkGray
     return
@@ -248,6 +396,13 @@ foreach ($install in $installs) {
             Write-Warn "$($install.Flavour) ficou como estava."
             continue
         }
+    }
+
+    # Com -Tor, prepara o daemon antes de injetar: o settings.json do patcher aponta para ele
+    # e o gateway segura ate o Tor responder (o bypass nunca cai direto no modo tor).
+    if ($Tor -and -not (Install-Tor)) {
+        Write-Warn 'O Tor nao subiu. Nao vou instalar o standalone no modo tor; tente de novo ou use -Proxy.'
+        break
     }
 
     Install-Patcher

--- a/standalone/GoLiveBypass-Standalone.ps1
+++ b/standalone/GoLiveBypass-Standalone.ps1
@@ -249,20 +249,18 @@ function Install-Tor {
     }
     [IO.File]::WriteAllText($TorTorrc, "SocksPort $TorPort`nDataDirectory $dataDir`n$geoipLines`Log notice stdout`n", (New-Object Text.UTF8Encoding $false))
 
-    # Servico do Windows precisa de admin; sem admin, Run key (sobe no logon).
-    $isAdmin = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-    if ($isAdmin) {
-        Write-Step 'Registrando o Tor como servico do Windows'
-        $result = & $TorExe --service install --service start 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warn "Nao consegui registrar o servico: $result"
-            Write-Step 'Tentando via chave de inicializacao do usuario (Run key)'
-            Set-RunKey
-        }
-    } else {
-        Write-Step 'Sem permissao de admin; registrando na inicializacao do usuario (Run key)'
-        Set-RunKey
-    }
+    # O caminho do Windows: o servico (tor.exe --service install) roda como LocalService e
+    # nao tem acesso a %LOCALAPPDATA% do usuario, entao o Tor nao consegue escrever no
+    # DataDirectory e o servico fica parado. A Run key sobe o Tor no logon do USUARIO — mesmo
+    # contexto da GUI — e e o caminho que funciona para o standalone/plugin, com ou sem admin.
+    # So vale a pena o servico se o DataDirectory morar em ProgramData (acessivel por
+    # LocalService); isso e o caso da GUI, nao dos instaladores.
+    Write-Step 'Registrando o Tor na inicializacao do usuario (sobe no logon)'
+    Set-RunKey
+
+    # A Run key so vale no proximo logon; para a sessao atual, sobe o daemon agora.
+    Write-Step 'Iniciando o Tor'
+    Start-Process -FilePath $TorExe -ArgumentList '-f', $TorTorrc -WindowStyle Hidden
 
     Write-Step 'Esperando o Tor subir'
     for ($i = 0; $i -lt 30; $i++) {
@@ -271,7 +269,7 @@ function Install-Tor {
     }
 
     if (-not (Test-TorReady)) {
-        Write-Warn 'Tor nao subiu em 30s. Veja o log em $TorDir\tor\data-state.'
+        Write-Warn "Tor nao subiu em 30s. Veja o log em $TorDir\tor\data-state."
         return $false
     }
     Write-Ok "Tor atendendo em 127.0.0.1:$TorPort"
@@ -290,20 +288,29 @@ function Set-RunKey {
 }
 
 function Remove-Tor {
-    # Para e desinstala o servico (se admin) e remove a Run key. O binario fica: a GUI usa o
-    # mesmo, e sem a GUI ele nao faz mal.
+    # Remove a Run key (o que este script cria). Se um servico "tor" existir de uma instalacao
+    # anterior (ex.: GUI), o deixamos em paz? Nao — se o binario e nosso (pasta GoLiveBypass),
+    # o servico aponta para ele e deve sair; senao e de outra pessoa.
     try {
-        $service = Get-CimInstance Win32_Service -Filter "Name='tor'" -ErrorAction SilentlyContinue
-        if ($service) {
-            Write-Step 'Parando e removendo o servico do Tor'
-            & $TorExe --service stop 2>&1 | Out-Null
-            & $TorExe --service remove 2>&1 | Out-Null
-        }
+        $key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+        Remove-ItemProperty -Path $key -Name 'GoLiveBypassTor' -ErrorAction SilentlyContinue
     } catch { }
 
-    try {
-        Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'GoLiveBypassTor' -ErrorAction SilentlyContinue
-    } catch { }
+    if (Test-Path -LiteralPath $TorExe) {
+        try {
+            $service = Get-CimInstance Win32_Service -Filter "Name='tor' AND PathName LIKE '%GoLiveBypass%'" -ErrorAction SilentlyContinue
+            if ($service) {
+                Write-Step 'Removendo o servico do Tor'
+                & $TorExe --service stop 2>&1 | Out-Null
+                & $TorExe --service remove 2>&1 | Out-Null
+            }
+        } catch { }
+    }
+
+    # O binario fica: a GUI usa o mesmo e sem ele nao faz mal.
+    if (Test-Path -LiteralPath $TorExe) {
+        Write-Host '  [*] O binario do Tor em %LOCALAPPDATA%\GoLiveBypass\Tor permanece (usado tambem pela GUI).' -ForegroundColor DarkGray
+    }
 }
 
 function Install-Injection($resources) {

--- a/standalone/golivebypass-standalone.sh
+++ b/standalone/golivebypass-standalone.sh
@@ -55,9 +55,24 @@ STUB_PACKAGE='{"name":"discord","main":"index.js","version":"1.0.0"}'
 FLATPAK_IDS="com.discordapp.Discord com.discordapp.DiscordPTB com.discordapp.DiscordCanary dev.vencord.Vesktop app.legcord.Legcord org.equicord.equibop"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
+# ---------------------------------------------------------------------------
+# Tor embutido: mesma versao, mesmos hashes e mesma porta da GUI
+# (golive-gui/electron/main.ts). A porta dedicada 9060 nao conflita com um Tor
+# do sistema (9050) nem do Tor Browser (9150).
+TOR_BUNDLE_VERSION="13.5"
+TOR_PORT="9060"
+TOR_BASE="$INSTALL_DIR/Tor"
+TOR_EXE="$TOR_BASE/tor/tor"
+TOR_TORRC="$TOR_BASE/torrc"
+TOR_TARBALL="tor-expert-bundle-linux-x86_64-$TOR_BUNDLE_VERSION.tar.gz"
+TOR_URL="https://archive.torproject.org/tor-package-archive/torbrowser/$TOR_BUNDLE_VERSION/$TOR_TARBALL"
+TOR_SHA256="147158f33c5f2c539d58d8fab69ca5af384778e7bbae951fbc7ac8ca58ac4e0d"
+TOR_SERVICE="golivebypass-tor.service"
+
 MODE="install"
 PROXY=""
 EXCLUDED="BR"
+TOR_MODE=0
 ASSUME_YES=0
 JSON=0
 
@@ -75,6 +90,7 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --proxy) PROXY="${2:-}"; shift ;;
         --excluded-countries) EXCLUDED="${2:-BR}"; shift ;;
+        --tor) TOR_MODE=1 ;;
         --uninstall) MODE="uninstall" ;;
         --restore) MODE="restore" ;;
         --status) MODE="status" ;;
@@ -538,7 +554,11 @@ install_patcher() {
     # arquivo. Regravar sem essas chaves apagava a escolha A CADA ativacao: o runtime
     # voltava ao "auto" em silencio enquanto a GUI seguia mostrando Tor.
     local route_mode="" tor_addr=""
-    if [ -f "$INSTALL_DIR/settings.json" ]; then
+    if [ "$TOR_MODE" -eq 1 ]; then
+        # --tor: aponta o bypass para o Tor que o proprio script instalou.
+        route_mode="tor"
+        tor_addr="127.0.0.1:$TOR_PORT"
+    elif [ -f "$INSTALL_DIR/settings.json" ]; then
         route_mode="$(sed -n 's/.*"routeMode"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$INSTALL_DIR/settings.json" | head -1)"
         tor_addr="$(sed -n 's/.*"torAddr"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$INSTALL_DIR/settings.json" | head -1)"
     fi
@@ -563,6 +583,146 @@ JSON
     # 600 porque o arquivo pode conter a senha da proxy da pessoa.
     chmod 600 "$INSTALL_DIR/settings.json" 2>/dev/null || true
     ok "Configuracao gravada em $INSTALL_DIR/settings.json"
+}
+
+# ---------------------------------------------------------------------------
+# Tor embutido (installation)
+
+tor_ready() {
+    # Probe barato: quem aceita TCP na 9060 e um SOCKS de Tor (nosso, da GUI ou do sistema).
+    if command -v bash >/dev/null 2>&1 && bash -c "exec 3<>/dev/tcp/127.0.0.1/$TOR_PORT" 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+# Baixa o bundle e deixa o binario pronto, se ainda nao existir. Nao sobe nada.
+ensure_tor_bundle() {
+    [ -x "$TOR_EXE" ] && return 0
+
+    step "Baixando o Tor (tor-expert-bundle $TOR_BUNDLE_VERSION, ~30 MB)"
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    if have curl; then
+        curl -fsSL "$TOR_URL" -o "$tmp/$TOR_TARBALL" || { warn "Falha ao baixar o Tor. Verifique sua conexao."; return 1; }
+    elif have wget; then
+        wget -qO- "$TOR_URL" > "$tmp/$TOR_TARBALL" || { warn "Falha ao baixar o Tor. Verifique sua conexao."; return 1; }
+    else
+        warn "Preciso de curl ou wget para baixar o Tor."
+        return 1
+    fi
+
+    step "Conferindo SHA-256"
+    local obtido
+    obtido="$(sha256sum "$tmp/$TOR_TARBALL" 2>/dev/null | cut -d' ' -f1)"
+    if [ "$obtido" != "$TOR_SHA256" ]; then
+        warn "O download do Tor veio corrompido (SHA-256 $obtido). Abortando."
+        return 1
+    fi
+
+    step "Extraindo o Tor"
+    mkdir -p "$TOR_BASE"
+    tar -xzf "$tmp/$TOR_TARBALL" -C "$TOR_BASE" --exclude 'tor/pluggable_transports/*' --exclude 'debug/*' || {
+        warn "Falha ao extrair o bundle do Tor."
+        return 1
+    }
+    chmod +x "$TOR_EXE" 2>/dev/null || true
+    return 0
+}
+
+# Garante o Tor de pe na 9060. Devolve 0 se estiver pronto.
+ensure_tor() {
+    tor_ready && { step "Tor ja atendendo em 127.0.0.1:$TOR_PORT"; return 0; }
+
+    have tor && step "Tor do sistema encontrado; verifica se o daemon esta de pe (porta $TOR_PORT)"
+
+    ensure_tor_bundle || return 1
+
+    mkdir -p "$TOR_BASE/data-state"
+    cat > "$TOR_TORRC" <<EOF
+SocksPort $TOR_PORT
+DataDirectory $TOR_BASE/data-state
+$( [ -f "$TOR_BASE/tor/data/geoip" ] && printf 'GeoIPFile %s\n' "$TOR_BASE/tor/data/geoip" )
+$( [ -f "$TOR_BASE/tor/data/geoip6" ] && printf 'GeoIPv6File %s\n' "$TOR_BASE/tor/data/geoip6" )
+Log notice stdout
+EOF
+
+    # systemd user (padrao); com sudo sem systemd user, unit system com User=<SUDO_USER>;
+    # ultimo recurso (sem systemd): nohup com aviso de que nao sobrevive ao boot.
+    if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
+        step "Registrando o Tor como servico do usuario (systemd user)"
+        mkdir -p "$HOME/.config/systemd/user"
+        cat > "$HOME/.config/systemd/user/$TOR_SERVICE" <<EOF
+[Unit]
+Description=GoLiveBypass Tor (SOCKS 127.0.0.1:$TOR_PORT)
+After=network.target
+
+[Service]
+ExecStart=$TOR_EXE -f $TOR_TORRC
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+EOF
+        systemctl --user daemon-reload
+        systemctl --user enable --now "$TOR_SERVICE" 2>/dev/null || {
+            warn "Nao consegui ativar o servico do usuario. Tentando nohup."
+            nohup "$TOR_EXE" -f "$TOR_TORRC" > "$TOR_BASE/tor.log" 2>&1 &
+        }
+    elif command -v systemctl >/dev/null 2>&1; then
+        local real_user="${SUDO_USER:-$USER}"
+        step "Registrando o Tor como servico do sistema (via sudo)"
+        sudo tee "/etc/systemd/system/$TOR_SERVICE" >/dev/null <<EOF
+[Unit]
+Description=GoLiveBypass Tor (SOCKS 127.0.0.1:$TOR_PORT)
+After=network.target
+
+[Service]
+User=$real_user
+ExecStart=$TOR_EXE -f $TOR_TORRC
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+        sudo systemctl daemon-reload
+        sudo systemctl enable --now "$TOR_SERVICE" 2>/dev/null || {
+            warn "Nao consegui ativar o servico do sistema. Tentando nohup."
+            nohup "$TOR_EXE" -f "$TOR_TORRC" > "$TOR_BASE/tor.log" 2>&1 &
+        }
+    else
+        step "systemd nao encontrado; rodando o Tor em background (nao sobrevive ao boot)"
+        nohup "$TOR_EXE" -f "$TOR_TORRC" > "$TOR_BASE/tor.log" 2>&1 &
+    fi
+
+    step "Esperando o Tor subir"
+    local i
+    for i in $(seq 1 30); do
+        tor_ready && break
+        sleep 1
+    done
+
+    if tor_ready; then
+        step "Tor atendendo em 127.0.0.1:$TOR_PORT"
+        return 0
+    fi
+    warn "O Tor nao subiu em 30s. Veja o log em $TOR_BASE/tor.log"
+    return 1
+}
+
+remove_tor() {
+    # Desinstala o que este script criou. Nao apaga o binario (a GUI usa o mesmo).
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl --user disable --now "$TOR_SERVICE" 2>/dev/null
+        rm -f "$HOME/.config/systemd/user/$TOR_SERVICE"
+        systemctl --user daemon-reload 2>/dev/null
+        if [ -f "/etc/systemd/system/$TOR_SERVICE" ]; then
+            sudo systemctl disable --now "$TOR_SERVICE" 2>/dev/null
+            sudo rm -f "/etc/systemd/system/$TOR_SERVICE"
+            sudo systemctl daemon-reload 2>/dev/null
+        fi
+    fi
+    rm -f "$HOME/.config/systemd/user/$TOR_SERVICE"
 }
 
 # Devolve 1 em qualquer falha, sem matar o script (set -eu mataria o processo inteiro se
@@ -711,6 +871,7 @@ if [ "$MODE" = "uninstall" ]; then
     # Nao reabrir o Discord nao-revertido: abriria com a injecao ainda no disco, e o botao
     # da GUI voltaria a "Ativo" por engano. Se nada falhou e ha um vanilla pra abrir, abre.
     if [ "$failed" -eq 0 ]; then
+        remove_tor
         start_discord "$(printf '%s\n' "$FOUND" | head -1)"
         exit 0
     fi
@@ -732,6 +893,7 @@ if [ "$MODE" = "restore" ]; then
             revoke_flatpak_access "$id" "$INSTALL_DIR"
         fi
     done
+    remove_tor
     exit 0
 fi
 
@@ -758,6 +920,14 @@ while IFS='|' read -r resources flav detect id; do
         warn "Flatpak do $id: a injecao por pasta app.asar nao abre este cliente (Electron 18/zypak)."
         printf '      %sPrefira a versao nativa (pacote da distro, AUR, deb/rpm) deste cliente.%s\n' "$C_DIM" "$C_OFF" >&2
         confirm "Mesmo assim injetar em $id?" || { warn "Deixei como estava."; continue; }
+    fi
+
+    # Com --tor, prepara o daemon antes de injetar: o settings.json aponta para ele e o
+    # gateway segura ate o Tor responder (o bypass nunca cai direto no modo tor).
+    if [ "$TOR_MODE" -eq 1 ] && ! ensure_tor; then
+        warn "O Tor nao subiu. Nao vou instalar o standalone no modo tor; tente de novo ou use --proxy."
+        printf '0\n' >> "$tally"
+        continue
     fi
 
     install_patcher


### PR DESCRIPTION
## O que faz

Os 4 CLIs (plugin Win/Linux e standalone Win/Linux) ganham o modo **Tor automatico**: baixam o mesmo expert bundle 13.5 da GUI, conferem SHA-256, extraem e registram o Tor como servico persistente na porta **9060**.

## Mudancas

- **installer/GoLiveBypass-Installer.ps1**: menu [2] vira "Tor automatico"; instalacao + Run key (sobe no logon); remove no uninstall/restore
- **installer/golivebypass-installer.sh**: espelho POSIX (`ensure_tor`); systemd user -> system com `User=<SUDO_USER>` -> nohup
- **goLiveBypass/native.ts**: `TOR_PORTS` = `[9060, 9052, 9150, 9050, 9250]` (nosso Tor primeiro)
- **standalone/GoLiveBypass-Standalone.ps1**: flag `-Tor` grava `routeMode=tor` + `torAddr=127.0.0.1:9060`; remove no uninstall
- **standalone/golivebypass-standalone.sh**: flag `--tor` idem; preserva `routeMode` sem flag; remove unit no uninstall/restore

## Validacao

- **VM Windows real**: download 30MB -> SHA -> extracao -> Run key -> Start-Process -> Tor escutando na 9060; settings.json correto; uninstall removeu Run key e restaurou Discord; `tor --verify-config` OK
- **Containers Linux**: suite POSIX 51 ok (2 falhas ksh/mksh pre-existentes); sandbox testou `ensure_tor` e `install_patcher --tor`
- **Bug encontrado e corrigido**: servico do Windows roda como LocalService sem acesso ao `%LOCALAPPDATA%` do usuario; trocado por Run key (mesmo contexto da GUI)

Docs: [design](docs/superpowers/specs/2026-08-24-tor-cli-design.md)