### PR TITLE
tui + report de bugs automatico nos instaladores de terminal

### DIFF
--- a/docs/superpowers/specs/2026-08-24-tui-opencode-design.md
+++ b/docs/superpowers/specs/2026-08-24-tui-opencode-design.md
@@ -1,0 +1,92 @@
+# Design — TUI ANSI estilo OpenCode nos instaladores
+
+**Data:** 2026-08-24
+**Status:** Aprovado pelo usuário (design apresentado em seções: arquitetura + telas/fluxos; implementação aprovada)
+**Objetivo:** substituir os menus `[1]/[2]/[3]` dos 4 CLIs por uma TUI interativa estilo OpenCode (dark, monospace, caixas, setas/Enter, mouse onde o terminal permite), embutida nos próprios scripts — sem binário, sem dependências novas.
+
+## 1. Princípios
+
+- **TUI artesanal ANSI puro**, dentro de cada script (PowerShell no Win, POSIX sh no Linux) — sem Node, sem .NET, sem pacote.
+- **Visual estilo OpenCode:** background escuro, texto claro monoespaçado, caixas `┌─┐│└┘`, seleção `●/○`, input no rodapé, barra de hints `[↑↓] navegar · [Enter] escolher · [Esc] cancelar`.
+- **Mouse como trade-off:** só em terminais com SGR mouse reporting (Windows Terminal, kitty, alacritty, wezterm, foot). Onde não há, cai para teclado (setas/Enter/j/k). Nunca quebra.
+- **TTY interativo → TUI; sem TTY ou `-Yes/--yes` → comportamento atual (menus/flags).** Automação e testes (que rodam `--yes`) nunca entram na TUI.
+
+## 2. Arquitetura
+
+### 2.1 Primitivos TUI (mesma API nos 4, implementações separadas ps1/sh)
+
+| Primitivo | Uso |
+|---|---|
+| `tui_is_interactive()` | `[ -t 0 ] && [ -t 1 ]` (sh) / `-not [Console]::IsInputRedirected` (ps1) |
+| `tui_box` | desenha caixa com título |
+| `tui_title` | header (logo + versão) |
+| `tui_menu(items)` | lista selecionável `●/○` (retorna índice) |
+| `tui_select(title, opts)` | menu de opções (retorna opção) |
+| `tui_input(label)` | campo de texto com cursor |
+| `tui_confirm(question)` | `s/N` estilizado |
+| `tui_status(...)` | tela de status |
+| `tui_progress(step_text)` | spinner/status de execução |
+
+### 2.2 Eventos
+
+- **Setas:** `Up`/`Down` / `k`/`j` movem o cursor.
+- **Enter:** confirma; **Esc:** cancela/volta.
+- **Mouse:** `\e[?1000h\e[?1006h` liga; interpreta `\e[<b>;<x>;<y>M`/`m` (SGR cliques); converte `y` em índice. Desliga ao sair (`\e[?1000l\e[?1006l`).
+
+## 3. Telas por CLI
+
+### 3.1 Instalador plugin (`installer/*`)
+
+```
+[1] Menu principal: Instalar/Atualizar · Remover plugin · Restaurar tudo · Ver status · Sair
+[2] Wizard destino (se sem $root): Usar existente · Baixar outro
+[3] Rede: Proxy gratuita · Tor automático · Proxy minha
+[4] Input (se Proxy minha): socks5://host:porta
+[5] Persistência: Permanente · Temporário
+[6] Resumo + confirmação
+[7] Execução com progresso (spinner) → OK
+```
+
+- `Select-Proxy`/`Select-Persistence`/`Select-Target`/`Show-ModChoice` viram `tui_select` (retornam o mesmo valor que hoje — ex.: `socks5://127.0.0.1:9060`, `''`, `$true/$false`).
+- `Install-Tor` e demais ações inalteradas; só o feedback vira `tui_progress`.
+
+### 3.2 Standalone (`standalone/*`)
+
+```
+[1] Menu: Instalar/Atualizar · Ver status · Desinstalar · Sair
+[2] Rede (se instalar): Tor automático · Proxy gratuita · Proxy minha
+[3] Confirmar
+[4] Execução (spinner) → OK
+```
+
+- `-Mode Install` sem flags → TUI se interativo; com `-Tor`/`-Proxy`/`-Yes` → direto (flags), como hoje.
+- `-Mode Status`/`Uninstall`/`Restore` sem TTY → atual; com TTY, uninstall/restore ganham `tui_confirm`.
+
+## 4. Integração com o código existente
+
+- As funções de domínio (instalação, Tor, settings, injeção, restore) **não mudam** — apenas os pontos de entrada de menu (`Show-MainMenu`/`main_menu`, `Select-*`, fluxo principal) passam a usar os primitivos TUI.
+- Fallback: quando `tui_is_interactive()` é falso, chamamos os mesmos códigos de menu/flags de hoje (funções existentes intactas).
+
+## 5. Erros e casos de borda
+
+| Caso | Comportamento |
+|---|---|
+| Sem TTY (pipe/automação/CI) | Menus/flags atuais, sem TUI |
+| `--yes`/`-Yes` | Direto (flags), nunca TUI |
+| Terminal sem SGR mouse | Teclado apenas (setas/Enter/j/k) — sem erro |
+| Ctrl+C durante TUI | Restaura terminal (`\e[?25h` cursor, mouse off), sai limpo |
+| Terminal muito pequeno | Caixa se adapta (mín. 2 linhas de folga) ou avisa |
+
+## 6. Verificação
+
+- `bash -n` nos sh; parse dos ps1 (na VM Windows ou `pwsh` local se disponível).
+- `tests/test-posix.sh` completa (roda sem TTY/`--yes` — garante que nada regrediu).
+- Simulação de TTY no Linux: `script -qec "..."` ou pty (exercita `tui_menu`), com setas/Enter via alimentação de entrada.
+- Na VM Windows: rodar o instalador em terminal interativo (ou pty via `winpty`) e navegar com setas/clique.
+
+## 7. Arquivos
+
+- `installer/GoLiveBypass-Installer.ps1` — TUI + fallback
+- `installer/golivebypass-installer.sh` — TUI + fallback
+- `standalone/GoLiveBypass-Standalone.ps1` — TUI + fallback
+- `standalone/golivebypass-standalone.sh` — TUI + fallback

--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -80,6 +80,53 @@ function Confirm-Action($question) {
     return (Read-Host "  $question [s/N]") -match '^[sSyY]'
 }
 
+# =========================================================================== Report de bugs
+# Igual a GUI: ao falhar, monta diagnostico sanitizado e POST na API de bugs
+# (abre issue no bezumiya/GoLiveBypass). Nunca bloqueia o fluxo.
+
+$script:BugApiUrl = 'https://api.skyplaceia.com/bugs/v1/reports'
+$script:BugApiToken = 'c3d0bff691ecc3ddc6f6ca10037b9ac967c62547e681d3749204e50800504511'
+
+function Invoke-BugReport([string]$title, [string]$description) {
+    if ($Yes) { return }  # automacao: nao spammar a API
+    $desc = Invoke-SanitizeBug $description
+    $body = @{ title = $title; description = $desc; includeLogs = $true } | ConvertTo-Json
+    try {
+        Invoke-RestMethod -Method Post -Uri $script:BugApiUrl -Body $body -ContentType 'application/json' -Headers @{ Authorization = "Bearer $($script:BugApiToken)" } -TimeoutSec 15 -ErrorAction Stop | Out-Null
+        Write-Host ''
+        Write-Host '  [OK] Relatorio enviado. Obrigado — os devs vao ver a issue no GitHub.' -ForegroundColor Green
+    } catch {
+        Write-Host ''
+        Write-Host '  [!] Nao consegui enviar o relatorio automatico. Rode de novo e mande a saida.' -ForegroundColor Yellow
+    }
+}
+
+function Invoke-SanitizeBug([string]$text) {
+    $text = [regex]::Replace($text, '([a-z][a-z0-9+.-]*://)([^/ @:]+):([^/@]+)@', '$1$2:***@')
+    $text = [regex]::Replace($text, '\b(mfa\.[A-Za-z0-9_-]{20,}|[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{27,})\b', '***')
+    $text = [regex]::Replace($text, '(https://gateway[^ ?]+)\?[^ ]*', '$1?<params>')
+    # proxy personalizada digitada na instalacao (nunca sai)
+    if ($script:UltimaProxy) { $text = $text.Replace($script:UltimaProxy, '<proxy-pessoal>') }
+    return $text
+}
+
+function Invoke-SendAutoReport([string]$summary, [string]$extra = '') {
+    if ($Yes) { return }
+    $desc = "$extra`n`n--- logs ---`n"
+    try {
+        $logDir = Join-Path $env:LOCALAPPDATA 'GoLiveBypass'
+        foreach ($log in @('golivebypass.log', 'gui.log')) {
+            $lp = Join-Path $logDir $log
+            if (Test-Path -LiteralPath $lp) {
+                $desc += (Get-Content -LiteralPath $lp -Tail 40 -ErrorAction SilentlyContinue | Out-String)
+            }
+        }
+    } catch { }
+    Invoke-BugReport $summary $desc
+}
+
+# =========================================================================== /Report de bugs
+
 # =========================================================================== TUI (PowerShell)
 # Interface no estilo OpenCode: dark, caixas, setas/Enter. Mouse: o console do Windows
 # nao expoe cliques de forma confiavel por aqui; a navegacao e por teclado (up/down/Enter/Esc/j/k)
@@ -1232,6 +1279,9 @@ try {
         Write-Host "      linha $($info.ScriptLineNumber): $($info.Line.Trim())" -ForegroundColor DarkGray
     }
     Write-Host '      Se for relatar, mande esta linha junto.' -ForegroundColor DarkGray
+
+    # Report automatico (se nao for automacao): a issue abre no GitHub.
+    Invoke-SendAutoReport "Falha no instalador GoLiveBypass: $($_.Exception.Message)" $_.Exception.Message
     exit 1
 }
 

--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
     GoLiveBypass - instalador automatico
 
     Encontra sozinho o Equicord ou o Vencord que voce tem, instala o plugin, compila e
@@ -79,6 +79,124 @@ function Confirm-Action($question) {
     if ($Yes) { return $true }
     return (Read-Host "  $question [s/N]") -match '^[sSyY]'
 }
+
+# =========================================================================== TUI (PowerShell)
+# Interface no estilo OpenCode: dark, caixas, setas/Enter. Mouse: o console do Windows
+# nao expoe cliques de forma confiavel por aqui; a navegacao e por teclado (up/down/Enter/Esc/j/k)
+# e o mouse SGR fica como melhoria futura. Sem TTY (pipe) ou com -Yes, cai para os menus atuais.
+
+function Test-TuiInteractive {
+    if ($Yes) { return $false }
+    return (-not [Console]::IsInputRedirected) -and (-not [Console]::IsOutputRedirected)
+}
+
+function Tui-Color($fg, $bg) { "`e[$fg`e[$bg" }  # acento/reset via ANSI
+
+# Pequena paleta da TUI (sempre ANSI; o console padrao do Windows suporta no WT/PowerShell 7).
+$script:TuiBg = "`e[48;5;235m"
+$script:TuiFg = "`e[38;5;252m"
+$script:TuiAccent = "`e[38;5;75m"
+$script:TuiOk = "`e[38;5;114m"
+$script:TuiDim = "`e[38;5;240m"
+$script:TuiBold = "`e[1m"
+$script:TuiRset = "`e[0m"
+
+function Tui-HideCursor { Write-Host "`e[?25l" -NoNewline }
+function Tui-ShowCursor { Write-Host "`e[?25h" -NoNewline }
+function Tui-ClearBelow([int]$row) { Write-Host "`e[$row;0H`e[J" -NoNewline }
+
+function Tui-GetKey {
+    # Na janela do Windows (powershell.exe), [Console]::ReadKey($true) captura setas e Enter.
+    try {
+        $k = [Console]::ReadKey($true)
+        switch ($k.Key) {
+            'UpArrow'  { return 'up' }
+            'DownArrow' { return 'down' }
+            'Enter'    { return 'enter' }
+            'Escape'   { return 'esc' }
+            default {
+                if ($k.KeyChar -eq 'j') { return 'down' }
+                if ($k.KeyChar -eq 'k') { return 'up' }
+                if ($k.KeyChar -eq 'q') { return 'esc' }
+                return 'other'
+            }
+        }
+    } catch { return 'other' }
+}
+
+function Tui-Box([string]$title, [string[]]$lines) {
+    $w = 62
+    $top = '─' * ($w - 8)
+    $bottom = '─' * ($w - 2)
+    Write-Host "$($script:TuiBg)$($script:TuiRset)┌─ $($script:TuiAccent)$title$($script:TuiRset) ─$($script:TuiDim)$top$($script:TuiRset)" -NoNewline
+    Write-Host ''
+    foreach ($txt in $lines) {
+        $pad = ' ' * [Math]::Max(0, ($w - 4 - $txt.Length))
+        Write-Host "$($script:TuiBg)$($script:TuiRset)│ $txt$pad │$($script:TuiRset)" -NoNewline
+        Write-Host ''
+    }
+    Write-Host "$($script:TuiBg)$($script:TuiRset)└$bottom┘$($script:TuiRset)" -NoNewline
+    Write-Host ''
+}
+
+function Tui-Menu([string]$title, [string[]]$items) {
+    if (-not (Test-TuiInteractive)) { return 0 }
+    $sel = 0
+    $n = $items.Count
+    Tui-HideCursor
+    try {
+        while ($true) {
+            Tui-ClearBelow 1
+            Write-Host "`r" -NoNewline
+            $top = '─' * (62 - 8)
+            Write-Host "$($script:TuiBg)$($script:TuiRset)┌─ $($script:TuiAccent)$title$($script:TuiRset) ─$($script:TuiDim)$top$($script:TuiRset)" -NoNewline
+            Write-Host ''
+            for ($i = 0; $i -lt $n; $i++) {
+                $txt = $items[$i]
+                $pad = ' ' * [Math]::Max(0, (62 - 6 - $txt.Length))
+                if ($i -eq $sel) {
+                    Write-Host "$($script:TuiBg)│ $($script:TuiAccent)●$($script:TuiRset) $($script:TuiBold)$txt$($script:TuiRset)$pad │$($script:TuiRset)" -NoNewline
+                } else {
+                    Write-Host "$($script:TuiBg)│ $($script:TuiDim)○$($script:TuiRset) $txt$pad │$($script:TuiRset)" -NoNewline
+                }
+                Write-Host ''
+            }
+            Write-Host "$($script:TuiBg)└$('─' * (62 - 2))┘$($script:TuiRset)" -NoNewline
+            Write-Host ''
+            Write-Host "  $($script:TuiDim)[↑↓] navegar · [Enter] escolher · [Esc] cancelar$($script:TuiRset)" -NoNewline
+            $key = Tui-GetKey
+            switch ($key) {
+                'up'   { if ($sel -gt 0) { $sel-- } }
+                'down' { if ($sel -lt $n - 1) { $sel++ } }
+                'enter' { break }
+                'esc'  { $sel = -1; break }
+            }
+            if ($key -eq 'enter' -or $key -eq 'esc') { break }
+        }
+    } finally {
+        Tui-ShowCursor
+    }
+    if ($sel -ge 0) { return $sel + 1 } else { return 0 }
+}
+
+function Tui-Input([string]$label, [string]$initial = '') {
+    Write-Host "$($script:TuiBg)$($script:TuiFg)  ${label}: $($script:TuiAccent)$initial" -NoNewline
+    Tui-ShowCursor
+    $v = Read-Host
+    Tui-HideCursor
+    return ($v -replace '\s+$', '')
+}
+
+function Tui-Confirm([string]$question) {
+    if (-not (Test-TuiInteractive)) { return (Confirm-Action $question) }
+    $ans = Read-Host "$($script:TuiBg)$($script:TuiFg)  $question [s/N]"
+    return ($ans -match '^[sSyY]')
+}
+
+function Tui-Progress([string]$msg) { Write-Host "$($script:TuiBg)`e[2K`r$($script:TuiAccent)[*]$($script:TuiRset) $msg" -NoNewline }
+function Tui-Done { Write-Host "$($script:TuiBg)`e[2K`r$($script:TuiOk)[OK]$($script:TuiRset)" }
+
+# =========================================================================== /TUI
 
 function Save-Text($path, $text) {
     $dir = Split-Path -Parent $path
@@ -300,6 +418,15 @@ function Show-ModChoice {
     if ($Mod) { return $Mod }
 
     $installed = Get-InstalledMod
+
+    if (Test-TuiInteractive) {
+        $tui = Tui-Menu 'Qual mod instalar?' @("Equicord — $($Mods.Equicord.Note)", "Vencord — $($Mods.Vencord.Note)")
+        switch ($tui) {
+            1 { return 'Equicord' }
+            2 { return 'Vencord' }
+            default { throw 'Cancelado.' }
+        }
+    }
 
     Write-Host ''
     if ($installed) {
@@ -713,6 +840,13 @@ function Select-Target($root) {
     if ($Yes) { return $root }
 
     $name = Split-Path -Leaf $root
+
+    if (Test-TuiInteractive) {
+        $tui = Tui-Menu 'Onde instalar?' @("Usar o $name que ja esta aqui", "Baixar e usar outro (Equicord ou Vencord)")
+        if ($tui -eq 2) { return (Install-Mod (Show-ModChoice)) }
+        return $root
+    }
+
     Write-Host '  Onde instalar?' -ForegroundColor White
     Write-Host ''
     Write-Host "    [1] Usar o $name que ja esta aqui" -ForegroundColor Green
@@ -904,6 +1038,31 @@ function Remove-Tor {
 function Select-Proxy {
     if ($Yes) { return '' }
 
+    if (Test-TuiInteractive) {
+        $tui = Tui-Menu 'Como o bypass vai sair para fora do Brasil?' @(
+            'Proxy gratuita (escolhida e testada sozinha)',
+            'Tor automatico (baixa e sobe sozinho)',
+            'Proxy minha (socks5://host:porta)'
+        )
+        switch ($tui) {
+            2 {
+                if (-not (Install-Tor)) {
+                    Write-Warn 'Nao deu para preparar o Tor. Seguindo com proxy gratuita.'
+                    return ''
+                }
+                return "socks5://127.0.0.1:$TorPort"
+            }
+            3 {
+                $manual = (Tui-Input 'Endereco da proxy').Trim()
+                if ($manual -notmatch '^(socks5|https?)://(?:.+@)?[a-z0-9.-]{1,253}:\d{1,5}(?:-\d{1,5})?$') {
+                    throw 'Formato invalido. Use socks5://host:porta, ou socks5://usuario:senha@host:porta.'
+                }
+                return $manual
+            }
+            default { return '' }
+        }
+    }
+
     Write-Host ''
     Write-Host '  Como o bypass vai sair para fora do Brasil?' -ForegroundColor White
     Write-Host ''
@@ -940,6 +1099,14 @@ function Select-Proxy {
 
 function Select-Persistence {
     if ($Yes) { return $true }
+
+    if (Test-TuiInteractive) {
+        $tui = Tui-Menu 'Como voce quer deixar o Discord?' @(
+            'Permanente (abre com o mod toda vez)',
+            'Temporario (desfaz quando voce fechar o Discord)'
+        )
+        return $tui -ne 2
+    }
 
     Write-Host ''
     Write-Host '  Como voce quer deixar o Discord?' -ForegroundColor White
@@ -1012,6 +1179,22 @@ function Invoke-RestoreEverything {
 function Show-MainMenu {
     $root = Find-Checkout
     Show-Status $root
+
+    if (Test-TuiInteractive) {
+        $tui = Tui-Menu 'O que voce quer fazer?' @(
+            'Instalar ou atualizar o GoLiveBypass',
+            'Remover so o plugin (o mod continua)',
+            'Restaurar tudo (remove o plugin e desfaz a injecao)',
+            'Sair'
+        )
+        switch ($tui) {
+            1 { Invoke-Install $root }
+            2 { Invoke-Uninstall }
+            3 { Invoke-RestoreEverything }
+            default { Write-Host '  Ate mais.' -ForegroundColor DarkGray }
+        }
+        return
+    }
 
     Write-Host '  O que voce quer fazer?' -ForegroundColor White
     Write-Host ''

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -105,7 +105,9 @@ confirm() {
 
 tui_is_interactive() {
     [ "$ASSUME_YES" -eq 1 ] && return 1
-    [ -t 0 ] && [ -t 1 ] && return 0
+    # stdin interativo e suficiente: o terminal do usuario tem stdin+stdout ttys, e
+    # exigir -t 1 quebra em pty/emuladores onde o stdout noutro momento nao reporta tty.
+    [ -t 0 ] && return 0
     return 1
 }
 
@@ -155,7 +157,8 @@ tui_size() {
         TUI_ROWS=24
         TUI_COLS=80
     fi
-    [ "$TUI_COLS" -le 20 ] && TUI_COLS=80
+    if [ "$TUI_COLS" -le 20 ]; then TUI_COLS=80; fi
+    return 0
 }
 
 # Posiciona o cursor em (row, col) — base 1, como o ANSI.
@@ -615,6 +618,24 @@ discord_resources() {
         /usr/local/share/discord \
         "$HOME/.local/share/discord" "$HOME/Discord" "$HOME/discord" \
         "$HOME/.local/share/DiscordPTB" "$HOME/.local/share/DiscordCanary"
+    do
+        [ -d "$raiz" ] || continue
+        for sub in "$raiz/resources" "$raiz"; do
+            if [ -e "$sub/app.asar" ] || [ -e "$sub/_app.asar" ]; then
+                printf '%s\n' "$sub"
+                break
+            fi
+        done
+    done
+
+    # Clientes paralelos (Vesktop/Equibop/Legcord) instalados por AUR/pacote: costumam morar
+    # em /usr/share, /usr/lib, /usr/lib64, /opt ou ~/.local/share. Espelhado do standalone.
+    for raiz in \
+        /usr/share/vesktop /usr/lib/vesktop /usr/lib64/vesktop /opt/vesktop /opt/Vesktop \
+        /usr/share/equibop /usr/lib/equibop /usr/lib64/equibop /opt/equibop /opt/Equibop \
+        /usr/share/legcord /usr/lib/legcord /usr/lib64/legcord /opt/legcord /opt/Legcord \
+        /usr/local/share/vesktop /usr/local/share/equibop /usr/local/share/legcord \
+        "$HOME/.local/share/vesktop" "$HOME/.local/share/equibop" "$HOME/.local/share/legcord"
     do
         [ -d "$raiz" ] || continue
         for sub in "$raiz/resources" "$raiz"; do

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -78,7 +78,13 @@ fi
 step() { printf '  %s[*] %s%s\n' "$C_DIM" "$1" "$C_OFF" >&2; }
 ok()   { printf '  %s[OK] %s%s\n' "$C_GREEN" "$1" "$C_OFF" >&2; }
 warn() { printf '  %s[!] %s%s\n' "$C_YELLOW" "$1" "$C_OFF" >&2; }
-fail() { printf '\n  %s[X] %s%s\n\n' "$C_RED" "$1" "$C_OFF" >&2; exit 1; }
+fail() {
+    printf '\n  %s[X] %s%s\n\n' "$C_RED" "$1" "$C_OFF" >&2
+    if [ "${REPORT_NO_AUTO:-0}" -eq 0 ]; then
+        report_error "Falha no instalador GoLiveBypass: $1" 2>&1 || true
+    fi
+    exit 1
+}
 
 banner() {
     printf '\n  %sGoLiveBypass%s\n' "$C_CYAN$C_BOLD" "$C_OFF"
@@ -96,6 +102,56 @@ confirm() {
         *) return 1 ;;
     esac
 }
+
+# =========================================================================== Report de bugs
+# Quando o instalador falha, monta um diagnostico (versao, OS, log sanitizado) e chama
+# a mesma API de bugs da GUI. A issue abre automaticamente no bezumiya/GoLiveBypass.
+# O envio NUNCA bloqueia o fluxo.
+
+BUG_API_URL="https://api.skyplaceia.com/bugs/v1/reports"
+BUG_API_TOKEN="c3d0bff691ecc3ddc6f6ca10037b9ac967c62547e681d3749204e50800504511"
+
+report_sanitize() {
+    local texto="$1"
+    texto="$(printf '%s' "$texto" | sed -E 's#([a-z][a-z0-9+.-]*://)([^/ @:]+):([^/@]+)@#\1\2:***@#g')"
+    texto="$(printf '%s' "$texto" | sed -E 's/\b(mfa\.[A-Za-z0-9_-]{20,}|[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{27,})\b/***/g')"
+    texto="$(printf '%s' "$texto" | sed -E 's#(https://gateway[^ ?]+)\?[^ ]*#\1?<params>#g')"
+    printf '%s' "$texto"
+}
+
+report_send() {
+    local titulo="$1" descricao="$2" corpo json
+    corpo="$(report_sanitize "$descricao")"
+    json="$(printf '{"title":"%s","description":"%s","includeLogs":true}' \
+        "$(printf '%s' "$titulo" | sed 's/"/\\"/g')" \
+        "$(printf '%s' "$corpo" | sed 's/"/\\"/g')")"
+    if have curl; then
+        curl -fsS -X POST "$BUG_API_URL" -H "Authorization: Bearer $BUG_API_TOKEN" -H "Content-Type: application/json" -d "$json" >/dev/null 2>&1 && return 0
+    elif have wget; then
+        echo "$json" | wget -qO- --post-data=- --header="Authorization: Bearer $BUG_API_TOKEN" --header="Content-Type: application/json" "$BUG_API_URL" >/dev/null 2>&1 && return 0
+    fi
+    return 1
+}
+
+report_error() {
+    local titulo="$1" desc=""
+    # pega a ultima mensagem de erro visivel (passthrough) + cauda de logs
+    if [ -f "$INSTALL_DIR/golivebypass.log" ]; then
+        desc="$(tail -n 40 "$INSTALL_DIR/golivebypass.log" 2>/dev/null || true)"
+    fi
+    if [ -n "$desc" ]; then
+        printf '  %s[!]%s Ocorreu um erro. Enviando relatorio automatico (issue no GitHub)...%s\n' "$C_YELLOW" "$C_OFF" "$C_OFF" >&2
+        if report_send "$titulo" "$desc"; then
+            printf '  %s[OK]%s Relatorio enviado. Obrigado — os devs vao ver a issue no GitHub.%s\n' "$C_GREEN" "$C_OFF" "$C_OFF" >&2
+        else
+            printf '  %s[!]%s Nao consegui enviar o relatorio automatico. Mande esta saida.%s\n' "$C_YELLOW" "$C_OFF" "$C_OFF" >&2
+        fi
+    else
+        printf '  %s[!]%s Nao consegui montar o relatorio (sem logs). Mande o erro acima.%s\n' "$C_YELLOW" "$C_OFF" "$C_OFF" >&2
+    fi
+}
+
+# =========================================================================== /Report de bugs
 
 # =========================================================================== TUI
 # Interface no estilo OpenCode: dark, caixas, setas/Enter, mouse SGR onde o terminal
@@ -313,6 +369,10 @@ tui_done() {
 # =========================================================================== /TUI
 
 have() { command -v "$1" >/dev/null 2>&1; }
+
+# Em automacao (--yes) o report automatico nao deve spammar a API (test/CI).
+# Usuario de verdade sem --yes reporta.
+[ "$ASSUME_YES" -eq 1 ] && REPORT_NO_AUTO=1 || REPORT_NO_AUTO=0
 
 # O id do flatpak a que um caminho pertence, ou nada se o caminho nao for de flatpak. Serve
 # para os dois lugares onde o Discord de flatpak aparece: o deploy em .../flatpak/app/<id>/ e

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -144,6 +144,23 @@ tui_box() {
     printf '%s%s└%s┘%s\n' "$TUI_BG" "$TUI_RSET" "$bottom" "$TUI_RSET" >&2
 }
 
+# Tamanho do terminal (linhas/colunas), com fallback 80x24 quando nao da para ler.
+tui_size() {
+    local s
+    if s="$(stty size 2>/dev/null)"; then
+        set -- $s
+        TUI_ROWS=${1:-24}
+        TUI_COLS=${2:-80}
+    else
+        TUI_ROWS=24
+        TUI_COLS=80
+    fi
+    [ "$TUI_COLS" -le 20 ] && TUI_COLS=80
+}
+
+# Posiciona o cursor em (row, col) — base 1, como o ANSI.
+tui_cursor() { printf '\033[%d;%dH' "$1" "$2" >&2; }
+
 # limpa a partir da linha N (para redesenhar o corpo sem o header).
 tui_clear_below() { printf '\033[%d;0H\033[J' "$1" >&2; }
 
@@ -186,6 +203,7 @@ tui_getkey() {
 }
 
 # tui_menu <title> <items...> → imprime o indice escolhido (1..N) ou "0" para cancelar.
+# Centraliza o box no meio do terminal (horizontal e vertical).
 tui_menu() {
     local title="$1"; shift
     local n sel key i txt
@@ -194,15 +212,26 @@ tui_menu() {
     tui_mouse_on
     tui_hide_cursor
     tui_raw_begin
+    tui_size
+    local w=62
+    local total_rows top pad margin_col margin_row
+    # total de linhas desenhadas: topo + n itens + rodape + hints(2) + 1 folga
+    total_rows=$((n + 5))
+    margin_col=$(( ( TUI_COLS - w ) / 2 ))
+    [ "$margin_col" -lt 1 ] && margin_col=1
+    margin_row=$(( ( TUI_ROWS - total_rows ) / 2 ))
+    [ "$margin_row" -lt 1 ] && margin_row=1
     while :; do
         tui_clear_below 1
-        local w=62
-        local top pad
         top=""
         i=0; while [ "$i" -lt $((w-8)) ]; do top="${top}─"; i=$((i+1)); done
+        r=$margin_row
+        tui_cursor $r $margin_col
         printf '%s%s┌─ %s%s%s ─%s%s%s\n' "$TUI_BG" "$TUI_RSET" "$TUI_ACCENT" "$title" "$TUI_RSET" "$TUI_DIM2" "$top" "$TUI_RSET" >&2
         i=0
         for txt in "$@"; do
+            r=$((r+1))
+            tui_cursor $r $margin_col
             pad=""
             local j
             j=0; while [ "$j" -lt $((w-6-${#txt})) ]; do pad="${pad} "; j=$((j+1)); done
@@ -213,8 +242,12 @@ tui_menu() {
             fi
             i=$((i+1))
         done
+        r=$((r+1))
+        tui_cursor $r $margin_col
         printf '%s└%s┘%s\n' "$TUI_BG" "$(printf '─%.0s' $(seq_like 1 $((w-2))))" "$TUI_RSET" >&2
-        printf '  %s[↑↓] navegar · [Enter] escolher · [Esc] cancelar%s\n' "$TUI_DIM2" "$TUI_RSET" >&2
+        r=$((r+1))
+        tui_cursor $r $margin_col
+        printf '%s  %s[↑↓] navegar · [Enter] escolher · [Esc] cancelar%s' "$TUI_BG" "$TUI_DIM2" "$TUI_RSET" >&2
         key="$(tui_getkey)"
         case "$key" in
             up)   [ "$sel" -gt 0 ] && sel=$((sel-1)) ;;

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -97,6 +97,185 @@ confirm() {
     esac
 }
 
+# =========================================================================== TUI
+# Interface no estilo OpenCode: dark, caixas, setas/Enter, mouse SGR onde o terminal
+# suporta. Tudo ANSI puro, sem dependencia. Quando nao ha TTY (pipe/automacao/CI) ou
+# --yes esta ligado, os scripts caem para os menus/flags de antes — nada muda nesses casos.
+# POSIX 100%: em vez de read -n (bash-only), usa stty -icanon + dd para ler 1 tecla.
+
+tui_is_interactive() {
+    [ "$ASSUME_YES" -eq 1 ] && return 1
+    [ -t 0 ] && [ -t 1 ] && return 0
+    return 1
+}
+
+# Cores extras da TUI (fundo escuro, texto claro, acento). Reutiliza C_* ja definidos.
+TUI_BG=$(printf '\033[48;5;235m')
+TUI_FG=$(printf '\033[38;5;252m')
+TUI_ACCENT=$(printf '\033[38;5;75m')   # azul-ciano (item ativo)
+TUI_OK=$(printf '\033[38;5;114m')      # verde (recomendado)
+TUI_DIM2=$(printf '\033[38;5;240m')
+TUI_BOLD=$(printf '\033[1m')
+TUI_RSET=$(printf '\033[0m')
+TUI_MOUSE_ON='\033[?1000h\033[?1006h'
+TUI_MOUSE_OFF='\033[?1000l\033[?1006l'
+
+tui_mouse_on()   { printf '%b' "$TUI_MOUSE_ON" >&2; }
+tui_mouse_off()  { printf '%b' "$TUI_MOUSE_OFF" >&2; }
+tui_hide_cursor() { printf '\033[?25l' >&2; }
+tui_show_cursor() { printf '\033[?25h' >&2; }
+
+# Desenha uma caixa com titulo e linhas de conteudo. Cada elemento de `lines` ja vem
+# com o texto pronto (sem as bordas).
+tui_box() {
+    local title="$1"; shift
+    local w=62 line txt i
+    local top bottom
+    top=""; bottom=""
+    i=0; while [ "$i" -lt $((w-8)) ]; do top="${top}─"; i=$((i+1)); done
+    i=0; while [ "$i" -lt $((w-2)) ]; do bottom="${bottom}─"; i=$((i+1)); done
+    printf '%s%s┌─ %s%s%s ─%s%s%s\n' "$TUI_BG" "$TUI_RSET" "$TUI_ACCENT" "$title" "$TUI_RSET" "$TUI_DIM2" "$top" "$TUI_RSET" >&2
+    for txt in "$@"; do
+        local pad
+        pad=""
+        i=0; while [ "$i" -lt $((w-4-${#txt})) ]; do pad="${pad} "; i=$((i+1)); done
+        printf '%s%s│ %s%s%s %s│%s\n' "$TUI_BG" "$TUI_RSET" "$txt" "$TUI_RSET" "$pad" "$TUI_BG" "$TUI_RSET" >&2
+    done
+    printf '%s%s└%s┘%s\n' "$TUI_BG" "$TUI_RSET" "$bottom" "$TUI_RSET" >&2
+}
+
+# limpa a partir da linha N (para redesenhar o corpo sem o header).
+tui_clear_below() { printf '\033[%d;0H\033[J' "$1" >&2; }
+
+# Modo "raw" POSIX: le 1 byte sem eco, sem esperar Enter. Guarda o estado do terminal para
+# restaurar. `dd` e `stty` existem em toda distro/busybox.
+tui_raw_begin() {
+    # salva o modo atual (só se stty funciona)
+    TUI_STTY_SAVED="$(stty -g 2>/dev/null || true)"
+    stty -icanon -echo 2>/dev/null || true
+}
+tui_raw_end() {
+    if [ -n "${TUI_STTY_SAVED:-}" ]; then
+        stty "$TUI_STTY_SAVED" 2>/dev/null || true
+    else
+        stty icanon echo 2>/dev/null || true
+    fi
+    TUI_STTY_SAVED=""
+}
+
+# Le uma tecla de navegacao em modo raw: retorna "up|down|enter|esc|j|k|other".
+# Mouse SGR chega como sequencia de bytes; tratamos o hit simples (press) como
+# "enter" quando clicou dentro da area do menu — aposicao e estimada pela linha.
+tui_getkey() {
+    local key rest
+    key="$(dd bs=1 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+    case "$key" in
+        1b) # ESC: ou so, ou seguido de [A/[B
+            rest="$(dd bs=1 count=2 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+            case "$rest" in
+                5b41) printf 'up\n' ;;      # ESC [ A
+                5b42) printf 'down\n' ;;     # ESC [ B
+                *)    printf 'esc\n' ;;      # ESC so
+            esac ;;
+        0a|0d) printf 'enter\n' ;;
+        6a) printf 'down\n' ;;               # j
+        6b) printf 'up\n' ;;                 # k
+        71) printf 'esc\n' ;;                # q
+        *) printf 'other\n' ;;
+    esac
+}
+
+# tui_menu <title> <items...> → imprime o indice escolhido (1..N) ou "0" para cancelar.
+tui_menu() {
+    local title="$1"; shift
+    local n sel key i txt
+    n=$#
+    sel=0
+    tui_mouse_on
+    tui_hide_cursor
+    tui_raw_begin
+    while :; do
+        tui_clear_below 1
+        local w=62
+        local top pad
+        top=""
+        i=0; while [ "$i" -lt $((w-8)) ]; do top="${top}─"; i=$((i+1)); done
+        printf '%s%s┌─ %s%s%s ─%s%s%s\n' "$TUI_BG" "$TUI_RSET" "$TUI_ACCENT" "$title" "$TUI_RSET" "$TUI_DIM2" "$top" "$TUI_RSET" >&2
+        i=0
+        for txt in "$@"; do
+            pad=""
+            local j
+            j=0; while [ "$j" -lt $((w-6-${#txt})) ]; do pad="${pad} "; j=$((j+1)); done
+            if [ "$i" -eq "$sel" ]; then
+                printf '%s│ %s●%s %s%s%s%s│%s\n' "$TUI_BG" "$TUI_ACCENT" "$TUI_RSET" "$TUI_BOLD" "$txt" "$TUI_RSET" "$pad" "$TUI_RSET" >&2
+            else
+                printf '%s│ %s○%s %s%s%s│%s\n' "$TUI_BG" "$TUI_DIM2" "$TUI_RSET" "$txt" "$TUI_RSET" "$pad" "$TUI_RSET" >&2
+            fi
+            i=$((i+1))
+        done
+        printf '%s└%s┘%s\n' "$TUI_BG" "$(printf '─%.0s' $(seq_like 1 $((w-2))))" "$TUI_RSET" >&2
+        printf '  %s[↑↓] navegar · [Enter] escolher · [Esc] cancelar%s\n' "$TUI_DIM2" "$TUI_RSET" >&2
+        key="$(tui_getkey)"
+        case "$key" in
+            up)   [ "$sel" -gt 0 ] && sel=$((sel-1)) ;;
+            down) [ "$sel" -lt $((n-1)) ] && sel=$((sel+1)) ;;
+            enter) break ;;
+            esc)  sel=-1; break ;;
+        esac
+    done
+    tui_raw_end
+    tui_mouse_off
+    tui_show_cursor
+    if [ "$sel" -ge 0 ] && [ "$sel" -lt "$n" ]; then printf '%d\n' $((sel+1)); else printf '0\n'; fi
+}
+
+# seq_like 1 N → 1 2 3 ... N (POSIX, sem `seq`).
+seq_like() {
+    local start="$1" end="$2" i
+    i="$start"
+    while [ "$i" -le "$end" ]; do printf '%d ' "$i"; i=$((i+1)); done
+}
+
+# tui_select <title> <opt1> <opt2> ... → igual a tui_menu (1-indexado).
+tui_select() { tui_menu "$@"; }
+
+# tui_confirm <question> → 0 se sim, 1 se nao. Aceita s/N (le uma linha).
+tui_confirm() {
+    tui_is_interactive || { confirm "$1"; return $?; }
+    local answer
+    printf '%s%s  %s [s/N] ' "$TUI_BG" "$TUI_FG" "$1" >&2
+    tui_show_cursor
+    read -r answer
+    tui_hide_cursor
+    case "$answer" in
+        [sSyY]*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# tui_input <label> <value_inicial> → imprime o valor digitado (ou o inicial se Enter vazio).
+tui_input() {
+    local label="$1" value="${2:-}"
+    printf '%s%s  %s%s: %s%s' "$TUI_BG" "$TUI_FG" "$label" "$TUI_ACCENT" "$value" >&2
+    tui_show_cursor
+    IFS= read -r value
+    tui_hide_cursor
+    printf '%s\n' "$value"
+}
+
+# tui_progress <texto> → spinner simples na linha (atualiza no lugar).
+tui_progress() {
+    local msg="$1"
+    printf '\033[2K\r%s%s[*]%s %s%s' "$TUI_BG" "$TUI_ACCENT" "$TUI_RSET" "$msg" "$TUI_RSET" >&2
+}
+
+# tui_done() → limpa a linha de progresso e imprime OK.
+tui_done() {
+    printf '\033[2K\r%s%s[OK]%s\n' "$TUI_BG" "$TUI_OK" "$TUI_RSET" >&2
+}
+
+# =========================================================================== /TUI
+
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # O id do flatpak a que um caminho pertence, ou nada se o caminho nao for de flatpak. Serve
@@ -589,6 +768,17 @@ choose_mod() {
 
     local installed
     installed="$(installed_mod || true)"
+
+    if tui_is_interactive; then
+        local tui_choice
+        tui_choice="$(tui_menu "Qual mod instalar?" "Equicord (recomendado, inclui tudo do Vencord)" "Vencord (o original, mais enxuto)")"
+        case "$tui_choice" in
+            1) echo "Equicord" ;;
+            2) echo "Vencord" ;;
+            *) fail "Cancelado." ;;
+        esac
+        return 0
+    fi
 
     printf '\n' >&2
     if [ -n "$installed" ]; then
@@ -1096,6 +1286,18 @@ select_target() {
 
     local name
     name="$(basename "$root")"
+
+    if tui_is_interactive; then
+        local tui_choice
+        tui_choice="$(tui_menu "Onde instalar?" "Usar o $name que ja esta aqui" "Baixar e usar outro (Equicord ou Vencord)")"
+        if [ "$tui_choice" = "2" ]; then
+            install_mod "$(choose_mod)"
+        else
+            printf '%s\n' "$root"
+        fi
+        return
+    fi
+
     printf '  %sOnde instalar?%s\n\n' "$C_BOLD" "$C_OFF" >&2
     printf '    %s[1] Usar o %s que ja esta aqui%s\n' "$C_GREEN" "$name" "$C_OFF" >&2
     printf '  %s      %s%s\n' "$C_DIM" "$root" "$C_OFF" >&2
@@ -1112,6 +1314,36 @@ select_target() {
 }
 
 select_proxy() {
+    if tui_is_interactive; then
+        local tui_choice
+        tui_choice="$(tui_menu "Como o bypass vai sair para fora do Brasil?" \
+            "Proxy gratuita (escolhida e testada sozinha)" \
+            "Tor automatico (baixa e sobe sozinho)" \
+            "Proxy minha (socks5://host:porta)")"
+        case "$tui_choice" in
+            2)
+                if ! ensure_tor; then
+                    warn "Nao deu para preparar o Tor. Seguindo com proxy gratuita."
+                    printf '\n'
+                    return 0
+                fi
+                printf 'socks5://127.0.0.1:%s\n' "$TOR_PORT"
+                ;;
+            3)
+                local manual
+                manual="$(tui_input "Endereco da proxy")"
+                case "$manual" in
+                    socks5://*|https://*|http://*)
+                        printf '%s' "$manual" | grep -Eq '^(socks5|https?)://(.+@)?[a-z0-9.-]{1,253}:[0-9]{1,5}(-[0-9]{1,5})?$' || fail "Formato invalido. Use socks5://host:porta, ou socks5://usuario:senha@host:porta." ;;
+                    *) fail "Formato invalido. Use socks5://host:porta, ou socks5://usuario:senha@host:porta." ;;
+                esac
+                printf '%s\n' "$manual"
+                ;;
+            *) printf '\n' ;;
+        esac
+        return 0
+    fi
+
     printf '\n  %sComo o bypass vai sair para fora do Brasil?%s\n\n' "$C_BOLD" "$C_OFF" >&2
     printf '    %s[1] Proxy gratuita, escolhida e testada sozinha%s\n' "$C_GREEN" "$C_OFF" >&2
     printf '  %s      Nao precisa instalar nada. O plugin testa varias e usa a que passar.%s\n' "$C_DIM" "$C_OFF" >&2
@@ -1153,6 +1385,15 @@ select_proxy() {
 }
 
 select_persistence() {
+    if tui_is_interactive; then
+        local tui_choice
+        tui_choice="$(tui_menu "Como voce quer deixar o Discord?" \
+            "Permanente (abre com o mod toda vez)" \
+            "Temporario (desfaz quando voce fechar o Discord)")"
+        [ "$tui_choice" = "2" ] && return 1
+        return 0
+    fi
+
     printf '\n  %sComo voce quer deixar o Discord?%s\n\n' "$C_BOLD" "$C_OFF" >&2
     printf '    %s[1] Permanente%s\n' "$C_GREEN" "$C_OFF" >&2
     printf '  %s      O Discord abre com o mod toda vez, ate voce remover.%s\n' "$C_DIM" "$C_OFF" >&2
@@ -1304,6 +1545,22 @@ main_menu() {
     local root
     root="$(find_checkout || true)"
     show_status "$root"
+
+    if tui_is_interactive; then
+        local tui_choice
+        tui_choice="$(tui_menu "O que voce quer fazer?" \
+            "Instalar ou atualizar o GoLiveBypass" \
+            "Remover so o plugin (o mod continua)" \
+            "Restaurar tudo (remove o plugin e desfaz a injecao)" \
+            "Sair")"
+        case "$tui_choice" in
+            1) do_install "$root" ;;
+            2) do_uninstall ;;
+            3) do_restore_everything ;;
+            *) printf '  %sAte mais.%s\n' "$C_DIM" "$C_OFF" ;;
+        esac
+        return
+    fi
 
     printf '  %sO que voce quer fazer?%s\n\n' "$C_BOLD" "$C_OFF"
     printf '    %s[1] Instalar ou atualizar o GoLiveBypass%s\n' "$C_GREEN" "$C_OFF"

--- a/standalone/GoLiveBypass-Standalone.ps1
+++ b/standalone/GoLiveBypass-Standalone.ps1
@@ -67,6 +67,56 @@ function Confirm-Action($question) {
     return $answer -match '^[sSyY]'
 }
 
+# =========================================================================== Report de bugs
+# Igual a GUI: ao falhar, monta diagnostico sanitizado e POST na API de bugs
+# (abre issue no bezumiya/GoLiveBypass). Nunca bloqueia o fluxo.
+
+$script:BugApiUrl = 'https://api.skyplaceia.com/bugs/v1/reports'
+$script:BugApiToken = 'c3d0bff691ecc3ddc6f6ca10037b9ac967c62547e681d3749204e50800504511'
+
+function Invoke-BugReport([string]$title, [string]$description) {
+    if ($Yes) { return }  # automacao: nao spammar a API
+    $desc = Invoke-SanitizeBug $description
+    $body = @{ title = $title; description = $desc; includeLogs = $true } | ConvertTo-Json
+    try {
+        Invoke-RestMethod -Method Post -Uri $script:BugApiUrl -Body $body -ContentType 'application/json' -Headers @{ Authorization = "Bearer $($script:BugApiToken)" } -TimeoutSec 15 -ErrorAction Stop | Out-Null
+        Write-Host ''
+        Write-Host '  [OK] Relatorio enviado. Obrigado — os devs vao ver a issue no GitHub.' -ForegroundColor Green
+    } catch {
+        Write-Host ''
+        Write-Host '  [!] Nao consegui enviar o relatorio automatico. Rode de novo e mande a saida.' -ForegroundColor Yellow
+    }
+}
+
+function Invoke-SanitizeBug([string]$text) {
+    $text = [regex]::Replace($text, '([a-z][a-z0-9+.-]*://)([^/ @:]+):([^/@]+)@', '$1$2:***@')
+    $text = [regex]::Replace($text, '\b(mfa\.[A-Za-z0-9_-]{20,}|[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{27,})\b', '***')
+    $text = [regex]::Replace($text, '(https://gateway[^ ?]+)\?[^ ]*', '$1?<params>')
+    # proxy personalizada salva
+    try {
+        $settings = Join-Path $InstallDir 'settings.json'
+        if (Test-Path -LiteralPath $settings) {
+            $p = (Get-Content -LiteralPath $settings -Raw | ConvertFrom-Json).proxy
+            if ($p) { $text = $text.Replace($p, '<proxy-pessoal>') }
+        }
+    } catch { }
+    return $text
+}
+
+function Invoke-AutoBugReport([string]$summary, [string]$extra = '') {
+    # monta a descricao: extra + cauda do log (se existir)
+    $logPath = Join-Path $InstallDir 'golivebypass.log'
+    $tail = ''
+    if (Test-Path -LiteralPath $logPath) {
+        $tail = (Get-Content -LiteralPath $logPath -Tail 40 -ErrorAction SilentlyContinue | Out-String)
+    }
+    if ($extra -or $tail) {
+        Invoke-BugReport $summary ($extra + "`n`n--- log ---`n" + $tail)
+    }
+}
+
+# =========================================================================== /Report de bugs
+
 # =========================================================================== TUI (PowerShell)
 # Interface no estilo OpenCode (dark, caixas, setas/Enter). Mouse: console do Windows nao
 # expoe cliques de forma confiavel; navegacao por teclado. Sem TTY ou com -Yes → flags.
@@ -471,6 +521,8 @@ if ($Mode -eq 'Status') { Show-Status; return }
 $installs = Get-DiscordResources
 if (-not $installs) { Write-Bad 'Nao achei nenhum Discord instalado.'; return }
 
+# corpo principal protegido: qualquer erro nao tratado vira report automatico
+try {
 # ---------------------------------------------------------------------------
 # Modo interativo (TUI): rodando sem -Mode Uninstall/Status, sem flags de proxy/tor
 # e com TTY, mostra um menu estilo OpenCode e deixa escolher a rede. Com -Yes ou
@@ -558,3 +610,8 @@ Write-Host '  Abra o Discord. O Go Live deve voltar sozinho.' -ForegroundColor G
 Write-Host "  Se algo der errado, o registro fica em $(Join-Path $InstallDir 'golivebypass.log')" -ForegroundColor DarkGray
 Write-Host '  Para desfazer: .\GoLiveBypass-Standalone.ps1 -Mode Uninstall' -ForegroundColor DarkGray
 Write-Host ''
+} catch {
+    Write-Host ''
+    Write-Bad "Erro: $($_.Exception.Message)"
+    Invoke-AutoBugReport 'Falha no GoLiveBypass standalone' $_.Exception.Message
+}

--- a/standalone/GoLiveBypass-Standalone.ps1
+++ b/standalone/GoLiveBypass-Standalone.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
     GoLiveBypass standalone - instalador
 
     Instala direto no Discord, sem Equicord e sem Vencord. Nao precisa de Node, nem de pnpm,
@@ -66,6 +66,101 @@ function Confirm-Action($question) {
     $answer = Read-Host "  $question [s/N]"
     return $answer -match '^[sSyY]'
 }
+
+# =========================================================================== TUI (PowerShell)
+# Interface no estilo OpenCode (dark, caixas, setas/Enter). Mouse: console do Windows nao
+# expoe cliques de forma confiavel; navegacao por teclado. Sem TTY ou com -Yes → flags.
+
+function Test-TuiInteractive {
+    if ($Yes) { return $false }
+    return (-not [Console]::IsInputRedirected) -and (-not [Console]::IsOutputRedirected)
+}
+
+$script:TuiBg = "`e[48;5;235m"
+$script:TuiFg = "`e[38;5;252m"
+$script:TuiAccent = "`e[38;5;75m"
+$script:TuiOk = "`e[38;5;114m"
+$script:TuiDim = "`e[38;5;240m"
+$script:TuiBold = "`e[1m"
+$script:TuiRset = "`e[0m"
+
+function Tui-HideCursor { Write-Host "`e[?25l" -NoNewline }
+function Tui-ShowCursor { Write-Host "`e[?25h" -NoNewline }
+function Tui-ClearBelow([int]$row) { Write-Host "`e[$row;0H`e[J" -NoNewline }
+
+function Tui-GetKey {
+    try {
+        $k = [Console]::ReadKey($true)
+        switch ($k.Key) {
+            'UpArrow'  { return 'up' }
+            'DownArrow' { return 'down' }
+            'Enter'    { return 'enter' }
+            'Escape'   { return 'esc' }
+            default {
+                if ($k.KeyChar -eq 'j') { return 'down' }
+                if ($k.KeyChar -eq 'k') { return 'up' }
+                if ($k.KeyChar -eq 'q') { return 'esc' }
+                return 'other'
+            }
+        }
+    } catch { return 'other' }
+}
+
+function Tui-Menu([string]$title, [string[]]$items) {
+    if (-not (Test-TuiInteractive)) { return 0 }
+    $sel = 0
+    $n = $items.Count
+    Tui-HideCursor
+    try {
+        while ($true) {
+            Tui-ClearBelow 1
+            Write-Host "`r" -NoNewline
+            $top = '─' * (62 - 8)
+            Write-Host "$($script:TuiBg)$($script:TuiRset)┌─ $($script:TuiAccent)$title$($script:TuiRset) ─$($script:TuiDim)$top$($script:TuiRset)" -NoNewline
+            Write-Host ''
+            for ($i = 0; $i -lt $n; $i++) {
+                $txt = $items[$i]
+                $pad = ' ' * [Math]::Max(0, (62 - 6 - $txt.Length))
+                if ($i -eq $sel) {
+                    Write-Host "$($script:TuiBg)│ $($script:TuiAccent)●$($script:TuiRset) $($script:TuiBold)$txt$($script:TuiRset)$pad │$($script:TuiRset)" -NoNewline
+                } else {
+                    Write-Host "$($script:TuiBg)│ $($script:TuiDim)○$($script:TuiRset) $txt$pad │$($script:TuiRset)" -NoNewline
+                }
+                Write-Host ''
+            }
+            Write-Host "$($script:TuiBg)└$('─' * (62 - 2))┘$($script:TuiRset)" -NoNewline
+            Write-Host ''
+            Write-Host "  $($script:TuiDim)[↑↓] navegar · [Enter] escolher · [Esc] cancelar$($script:TuiRset)" -NoNewline
+            $key = Tui-GetKey
+            switch ($key) {
+                'up'   { if ($sel -gt 0) { $sel-- } }
+                'down' { if ($sel -lt $n - 1) { $sel++ } }
+                'enter' { break }
+                'esc'  { $sel = -1; break }
+            }
+            if ($key -eq 'enter' -or $key -eq 'esc') { break }
+        }
+    } finally {
+        Tui-ShowCursor
+    }
+    if ($sel -ge 0) { return $sel + 1 } else { return 0 }
+}
+
+function Tui-Input([string]$label, [string]$initial = '') {
+    Write-Host "$($script:TuiBg)$($script:TuiFg)  ${label}: $($script:TuiAccent)$initial" -NoNewline
+    Tui-ShowCursor
+    $v = Read-Host
+    Tui-HideCursor
+    return ($v -replace '\s+$', '')
+}
+
+function Tui-Confirm([string]$question) {
+    if (-not (Test-TuiInteractive)) { return (Confirm-Action $question) }
+    $ans = Read-Host "$($script:TuiBg)$($script:TuiFg)  $question [s/N]"
+    return ($ans -match '^[sSyY]')
+}
+
+# =========================================================================== /TUI
 
 function Test-DiscordResourcesReady($resources) {
     $asar = Join-Path $resources 'app.asar'
@@ -375,6 +470,39 @@ if ($Mode -eq 'Status') { Show-Status; return }
 
 $installs = Get-DiscordResources
 if (-not $installs) { Write-Bad 'Nao achei nenhum Discord instalado.'; return }
+
+# ---------------------------------------------------------------------------
+# Modo interativo (TUI): rodando sem -Mode Uninstall/Status, sem flags de proxy/tor
+# e com TTY, mostra um menu estilo OpenCode e deixa escolher a rede. Com -Yes ou
+# sem TTY, o fluxo continua por flags (comportamento atual).
+if ($Mode -eq 'Install' -and (Test-TuiInteractive)) {
+    $tuiChoice = Tui-Menu 'GoLiveBypass standalone' @(
+        'Instalar / atualizar o bypass',
+        'Ver status',
+        'Desinstalar',
+        'Sair'
+    )
+    switch ($tuiChoice) {
+        2 {
+            Show-Status
+            return
+        }
+        3 {
+            $Mode = 'Uninstall'
+        }
+        0 { Write-Host '  Ate mais.' -ForegroundColor DarkGray; return }
+        default {
+            # Instalar: pede a rede antes de prosseguir.
+            $tuiNet = Tui-Menu 'Como o bypass vai sair?' @(
+                'Tor automatico (recomendado, baixa e sobe sozinho)',
+                'Proxy gratuita (escolhida e testada sozinha)',
+                'Proxy minha (socks5://host:porta)'
+            )
+            if ($tuiNet -eq 1) { $Tor = $true }
+            elseif ($tuiNet -eq 3) { $Proxy = (Tui-Input 'Endereco da proxy').Trim() }
+        }
+    }
+}
 
 if ($Mode -eq 'Uninstall') {
     Stop-Discord

--- a/standalone/golivebypass-standalone.sh
+++ b/standalone/golivebypass-standalone.sh
@@ -110,6 +110,21 @@ st_tui_mouse_off()  { printf '\033[?1000l\033[?1006l' >&2; }
 st_tui_hide_cursor() { printf '\033[?25l' >&2; }
 st_tui_show_cursor() { printf '\033[?25h' >&2; }
 
+# Tamanho do terminal + posicionamento (centraliza o box).
+st_tui_size() {
+    local s
+    if s="$(stty size 2>/dev/null)"; then
+        set -- $s
+        ST_ROWS=${1:-24}
+        ST_COLS=${2:-80}
+    else
+        ST_ROWS=24
+        ST_COLS=80
+    fi
+    [ "$ST_COLS" -le 20 ] && ST_COLS=80
+}
+st_tui_cursor() { printf '\033[%d;%dH' "$1" "$2" >&2; }
+
 st_tui_raw_begin() {
     ST_STTY_SAVED="$(stty -g 2>/dev/null || true)"
     stty -icanon -echo 2>/dev/null || true
@@ -149,6 +164,7 @@ st_seq() {
 }
 
 # st_tui_menu <title> <items...> → imprime indice (1..N) ou 0 para cancelar.
+# Centraliza o box no meio do terminal (horizontal e vertical).
 st_tui_menu() {
     local title="$1"; shift
     local n sel key i txt
@@ -157,14 +173,25 @@ st_tui_menu() {
     st_tui_mouse_on
     st_tui_hide_cursor
     st_tui_raw_begin
+    st_tui_size
+    local w=62
+    local total_rows top pad margin_col margin_row r
+    total_rows=$((n + 5))
+    margin_col=$(( ( ST_COLS - w ) / 2 ))
+    [ "$margin_col" -lt 1 ] && margin_col=1
+    margin_row=$(( ( ST_ROWS - total_rows ) / 2 ))
+    [ "$margin_row" -lt 1 ] && margin_row=1
     while :; do
         printf '\033[1;0H\033[J' >&2
-        local w=62 top pad
         top=""
         i=0; while [ "$i" -lt $((w-8)) ]; do top="${top}─"; i=$((i+1)); done
+        r=$margin_row
+        st_tui_cursor $r $margin_col
         printf '%s%s┌─ %s%s%s ─%s%s%s\n' "$ST_BG" "$ST_RSET" "$ST_ACCENT" "$title" "$ST_RSET" "$ST_DIM2" "$top" "$ST_RSET" >&2
         i=0
         for txt in "$@"; do
+            r=$((r+1))
+            st_tui_cursor $r $margin_col
             pad=""
             local j
             j=0; while [ "$j" -lt $((w-6-${#txt})) ]; do pad="${pad} "; j=$((j+1)); done
@@ -175,8 +202,12 @@ st_tui_menu() {
             fi
             i=$((i+1))
         done
+        r=$((r+1))
+        st_tui_cursor $r $margin_col
         printf '%s└%s┘%s\n' "$ST_BG" "$(printf '─%.0s' $(st_seq 1 $((w-2))))" "$ST_RSET" >&2
-        printf '  %s[↑↓] navegar · [Enter] escolher · [Esc] cancelar%s\n' "$ST_DIM2" "$ST_RSET" >&2
+        r=$((r+1))
+        st_tui_cursor $r $margin_col
+        printf '%s  %s[↑↓] navegar · [Enter] escolher · [Esc] cancelar%s' "$ST_BG" "$ST_DIM2" "$ST_RSET" >&2
         key="$(st_tui_getkey)"
         case "$key" in
             up)   [ "$sel" -gt 0 ] && sel=$((sel-1)) ;;

--- a/standalone/golivebypass-standalone.sh
+++ b/standalone/golivebypass-standalone.sh
@@ -93,7 +93,8 @@ fail() { printf '  %s[X]%s %s\n' "$C_RED" "$C_OFF" "$1" >&2; exit 1; }
 
 st_tui_is_interactive() {
     [ "$ASSUME_YES" -eq 1 ] && return 1
-    [ -t 0 ] && [ -t 1 ] && return 0
+    # stdin interativo e suficiente (evita quebrar em pty/emuladores).
+    [ -t 0 ] && return 0
     return 1
 }
 
@@ -121,7 +122,8 @@ st_tui_size() {
         ST_ROWS=24
         ST_COLS=80
     fi
-    [ "$ST_COLS" -le 20 ] && ST_COLS=80
+    if [ "$ST_COLS" -le 20 ]; then ST_COLS=80; fi
+    return 0
 }
 st_tui_cursor() { printf '\033[%d;%dH' "$1" "$2" >&2; }
 

--- a/standalone/golivebypass-standalone.sh
+++ b/standalone/golivebypass-standalone.sh
@@ -84,7 +84,89 @@ C_OFF=$(printf '\033[0m'); C_CYAN=$(printf '\033[36m'); C_GREEN=$(printf '\033[3
 step() { printf '  %s[*]%s %s\n' "$C_CYAN" "$C_OFF" "$1" >&2; }
 ok()   { printf '  %s[OK]%s %s\n' "$C_GREEN" "$C_OFF" "$1" >&2; }
 warn() { printf '  %s[!]%s %s\n' "$C_YELLOW" "$C_OFF" "$1" >&2; }
-fail() { printf '  %s[X]%s %s\n' "$C_RED" "$C_OFF" "$1" >&2; exit 1; }
+fail() {
+    printf '  %s[X]%s %s\n' "$C_RED" "$C_OFF" "$1" >&2
+    # Report automatico: so quando esta de fato falhando (e nao em --yes de teste).
+    if [ "${REPORT_NO_AUTO:-0}" -eq 0 ]; then
+        report_error "Falha no instalador GoLiveBypass: $1" 2>&1 || true
+    fi
+    exit 1
+}
+
+# =========================================================================== Report de bugs
+# Quando o instalador falha, monta um diagnostico (versao, OS, log sanitizado) e chama
+# a mesma API de bugs da GUI. A issue abre automaticamente no bezumiya/GoLiveBypass.
+# O envio NUNCA bloqueia o fluxo: falhou o report, avisa e segue.
+
+BUG_API_URL="https://api.skyplaceia.com/bugs/v1/reports"
+BUG_API_TOKEN="c3d0bff691ecc3ddc6f6ca10037b9ac967c62547e681d3749204e50800504511"
+
+# Sanitiza texto: credenciais em URL, tokens Discord, query de gateway, e a proxy salva.
+report_sanitize() {
+    local texto="$1"
+    # credenciais em URL: scheme://usuario:senha@host -> scheme://usuario:***@host
+    texto="$(printf '%s' "$texto" | sed -E 's#([a-z][a-z0-9+.-]*://)([^/ @:]+):([^/@]+)@#\1\2:***@#g')"
+    # tokens Discord (mfa.* / JWT)
+    texto="$(printf '%s' "$texto" | sed -E 's/\b(mfa\.[A-Za-z0-9_-]{20,}|[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{27,})\b/***/g')"
+    # query de gateway: so o host interessa
+    texto="$(printf '%s' "$texto" | sed -E 's#(https://gateway[^ ?]+)\?[^ ]*#\1?<params>#g')"
+    # proxy personalizada salva (host/porta e URL inteira)
+    if [ -f "$INSTALL_DIR/settings.json" ]; then
+        local segredo
+        segredo="$(sed -n 's/.*"proxy"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$INSTALL_DIR/settings.json" | head -1)"
+        if [ -n "$segredo" ]; then
+            texto="$(printf '%s' "$texto" | sed "s#$(printf '%s' "$segredo" | sed 's/[&/\]/\\&/g')#<proxy-pessoal>#g")"
+        fi
+    fi
+    printf '%s' "$texto"
+}
+
+# Envia o report para a API. Devolve 0 em caso de sucesso (issue aberta).
+report_send() {
+    local titulo="$1" descricao="$2"
+    local corpo
+    corpo="$(report_sanitize "$descricao")"
+    # JSON minimo: title, description, includeLogs
+    local json
+    json="$(printf '{"title":"%s","description":"%s","includeLogs":true}' \
+        "$(printf '%s' "$titulo" | sed 's/"/\\"/g')" \
+        "$(printf '%s' "$corpo" | sed 's/"/\\"/g')")"
+    if have curl; then
+        curl -fsS -X POST "$BUG_API_URL" \
+            -H "Authorization: Bearer $BUG_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$json" >/dev/null 2>&1 && return 0
+    elif have wget; then
+        echo "$json" | wget -qO- --post-data=- --header="Authorization: Bearer $BUG_API_TOKEN" --header="Content-Type: application/json" "$BUG_API_URL" >/dev/null 2>&1 && return 0
+    fi
+    return 1
+}
+
+# Chamada unica de report: mostra aviso e tenta enviar (sem bloquear).
+report_error() {
+    local titulo="$1"
+    local desc="$(cat 2>/dev/null || true)"
+    if [ -s /tmp/glb-report-context.txt ]; then
+        desc="$(cat /tmp/glb-report-context.txt 2>/dev/null || true) $desc"
+    fi
+    # Aqui entra a cauda do log se existir
+    if [ -f "$INSTALL_DIR/golivebypass.log" ]; then
+        desc="$desc
+$(tail -n 40 "$INSTALL_DIR/golivebypass.log" 2>/dev/null || true)"
+    fi
+    if [ -n "$desc" ]; then
+        printf '  %s[!]%s Ocorreu um erro. Enviando relatorio automatico (issue no GitHub)...%s\n' "$C_YELLOW" "$C_OFF" "$C_OFF" >&2
+        if report_send "$titulo" "$desc"; then
+            printf '  %s[OK]%s Relatorio enviado. Obrigado — os devs vao ver a issue no GitHub.%s\n' "$C_GREEN" "$C_OFF" "$C_OFF" >&2
+        else
+            printf '  %s[!]%s Nao consegui enviar o relatorio automatico. Rode com --json e mande a saida.%s\n' "$C_YELLOW" "$C_OFF" "$C_OFF" >&2
+        fi
+    else
+        printf '  %s[!]%s Nao consegui montar o relatorio (sem logs). Mande o erro acima.%s\n' "$C_YELLOW" "$C_OFF" "$C_OFF" >&2
+    fi
+}
+
+# =========================================================================== /Report de bugs
 
 # =========================================================================== TUI (standalone)
 # Interface no estilo OpenCode (dark, caixas, setas/Enter), ANSI puro, POSIX.
@@ -266,6 +348,10 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
+
+# Em automacao (--yes) o report automatico nao deve spammar a API: quase sempre essas
+# rodadas sao de teste/CI. Usuario de verdade sem --yes reporta.
+[ "$ASSUME_YES" -eq 1 ] && REPORT_NO_AUTO=1 || REPORT_NO_AUTO=0
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -1059,7 +1145,7 @@ if [ "$MODE" = "uninstall" ]; then
         start_discord "$(printf '%s\n' "$FOUND" | head -1)"
         exit 0
     fi
-    exit 1
+    fail "Nao consegui desinstalar de todos — a elevacao pode ter falhado. Enviando relatorio."
 fi
 
 # Igual ao --uninstall, mas sem reabrir o Discord: usado pela GUI no boot para reverter
@@ -1161,8 +1247,7 @@ start_discord "$(printf '%s\n' "$FOUND" | head -1)"
 if [ "$injected" -eq 0 ]; then
     # Nada foi injetado: nao reabrir (senao a GUI mostraria um "sucesso" mentiroso) e
     # falhar de verdade para o chamador enxergar.
-    printf '\n  %sNADA foi injetado — a elevacao falhou ou nenhum Discord foi tocado.%s\n' "$C_RED" "$C_OFF" >&2
-    exit 1
+    fail "NADA foi injetado — a elevacao falhou ou nenhum Discord foi tocado."
 fi
 printf '\n  %sDiscord aberto com o GoLiveBypass.%s\n' "$C_GREEN" "$C_OFF" >&2
 

--- a/standalone/golivebypass-standalone.sh
+++ b/standalone/golivebypass-standalone.sh
@@ -86,6 +86,138 @@ ok()   { printf '  %s[OK]%s %s\n' "$C_GREEN" "$C_OFF" "$1" >&2; }
 warn() { printf '  %s[!]%s %s\n' "$C_YELLOW" "$C_OFF" "$1" >&2; }
 fail() { printf '  %s[X]%s %s\n' "$C_RED" "$C_OFF" "$1" >&2; exit 1; }
 
+# =========================================================================== TUI (standalone)
+# Interface no estilo OpenCode (dark, caixas, setas/Enter), ANSI puro, POSIX.
+# Quando nao ha TTY, ou -y/--yes esta ligado, o script cai para o fluxo por flags.
+# As funcoes usam prefixo st_ para nao colidir com as do instalador de plugin.
+
+st_tui_is_interactive() {
+    [ "$ASSUME_YES" -eq 1 ] && return 1
+    [ -t 0 ] && [ -t 1 ] && return 0
+    return 1
+}
+
+ST_BG=$(printf '\033[48;5;235m')
+ST_FG=$(printf '\033[38;5;252m')
+ST_ACCENT=$(printf '\033[38;5;75m')
+ST_OK=$(printf '\033[38;5;114m')
+ST_DIM2=$(printf '\033[38;5;240m')
+ST_BOLD=$(printf '\033[1m')
+ST_RSET=$(printf '\033[0m')
+
+st_tui_mouse_on()   { printf '\033[?1000h\033[?1006h' >&2; }
+st_tui_mouse_off()  { printf '\033[?1000l\033[?1006l' >&2; }
+st_tui_hide_cursor() { printf '\033[?25l' >&2; }
+st_tui_show_cursor() { printf '\033[?25h' >&2; }
+
+st_tui_raw_begin() {
+    ST_STTY_SAVED="$(stty -g 2>/dev/null || true)"
+    stty -icanon -echo 2>/dev/null || true
+}
+st_tui_raw_end() {
+    if [ -n "${ST_STTY_SAVED:-}" ]; then
+        stty "$ST_STTY_SAVED" 2>/dev/null || true
+    else
+        stty icanon echo 2>/dev/null || true
+    fi
+    ST_STTY_SAVED=""
+}
+
+st_tui_getkey() {
+    local key rest
+    key="$(dd bs=1 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+    case "$key" in
+        1b)
+            rest="$(dd bs=1 count=2 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+            case "$rest" in
+                5b41) printf 'up\n' ;;
+                5b42) printf 'down\n' ;;
+                *)    printf 'esc\n' ;;
+            esac ;;
+        0a|0d) printf 'enter\n' ;;
+        6a) printf 'down\n' ;;
+        6b) printf 'up\n' ;;
+        71) printf 'esc\n' ;;
+        *) printf 'other\n' ;;
+    esac
+}
+
+st_seq() {
+    local start="$1" end="$2" i
+    i="$start"
+    while [ "$i" -le "$end" ]; do printf '%d ' "$i"; i=$((i+1)); done
+}
+
+# st_tui_menu <title> <items...> → imprime indice (1..N) ou 0 para cancelar.
+st_tui_menu() {
+    local title="$1"; shift
+    local n sel key i txt
+    n=$#
+    sel=0
+    st_tui_mouse_on
+    st_tui_hide_cursor
+    st_tui_raw_begin
+    while :; do
+        printf '\033[1;0H\033[J' >&2
+        local w=62 top pad
+        top=""
+        i=0; while [ "$i" -lt $((w-8)) ]; do top="${top}─"; i=$((i+1)); done
+        printf '%s%s┌─ %s%s%s ─%s%s%s\n' "$ST_BG" "$ST_RSET" "$ST_ACCENT" "$title" "$ST_RSET" "$ST_DIM2" "$top" "$ST_RSET" >&2
+        i=0
+        for txt in "$@"; do
+            pad=""
+            local j
+            j=0; while [ "$j" -lt $((w-6-${#txt})) ]; do pad="${pad} "; j=$((j+1)); done
+            if [ "$i" -eq "$sel" ]; then
+                printf '%s│ %s●%s %s%s%s%s│%s\n' "$ST_BG" "$ST_ACCENT" "$ST_RSET" "$ST_BOLD" "$txt" "$ST_RSET" "$pad" "$ST_RSET" >&2
+            else
+                printf '%s│ %s○%s %s%s%s│%s\n' "$ST_BG" "$ST_DIM2" "$ST_RSET" "$txt" "$ST_RSET" "$pad" "$ST_RSET" >&2
+            fi
+            i=$((i+1))
+        done
+        printf '%s└%s┘%s\n' "$ST_BG" "$(printf '─%.0s' $(st_seq 1 $((w-2))))" "$ST_RSET" >&2
+        printf '  %s[↑↓] navegar · [Enter] escolher · [Esc] cancelar%s\n' "$ST_DIM2" "$ST_RSET" >&2
+        key="$(st_tui_getkey)"
+        case "$key" in
+            up)   [ "$sel" -gt 0 ] && sel=$((sel-1)) ;;
+            down) [ "$sel" -lt $((n-1)) ] && sel=$((sel+1)) ;;
+            enter) break ;;
+            esc)  sel=-1; break ;;
+        esac
+    done
+    st_tui_raw_end
+    st_tui_mouse_off
+    st_tui_show_cursor
+    if [ "$sel" -ge 0 ] && [ "$sel" -lt "$n" ]; then printf '%d\n' $((sel+1)); else printf '0\n'; fi
+}
+
+# st_tui_confirm <question> → 0 sim, 1 nao
+st_tui_confirm() {
+    st_tui_is_interactive || return 1
+    local answer
+    printf '%s%s  %s [s/N] ' "$ST_BG" "$ST_FG" "$1" >&2
+    st_tui_show_cursor
+    read -r answer
+    st_tui_hide_cursor
+    case "$answer" in [sSyY]*) return 0 ;; *) return 1 ;; esac
+}
+
+# st_tui_input <label> <inicial>
+st_tui_input() {
+    local label="$1" value="${2:-}"
+    printf '%s%s  %s%s: %s%s' "$ST_BG" "$ST_FG" "$label" "$ST_ACCENT" "$value" >&2
+    st_tui_show_cursor
+    IFS= read -r value
+    st_tui_hide_cursor
+    printf '%s\n' "$value"
+}
+
+# st_tui_progress/done: linha de status com spinner simples.
+st_tui_progress() { printf '\033[2K\r%s%s[*]%s %s%s' "$ST_BG" "$ST_ACCENT" "$ST_RSET" "$1" "$ST_RSET" >&2; }
+st_tui_done() { printf '\033[2K\r%s%s[OK]%s\n' "$ST_BG" "$ST_OK" "$ST_RSET" >&2; }
+
+# =========================================================================== /TUI (standalone)
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --proxy) PROXY="${2:-}"; shift ;;
@@ -808,6 +940,25 @@ DISTRO="$(os_field PRETTY_NAME)"
 [ -n "$DISTRO" ] || DISTRO="Linux"
 printf '  %s%s%s\n\n' "$C_DIM" "$DISTRO" "$C_OFF" >&2
 
+# ---------------------------------------------------------------------------
+# Modo interativo (TUI): quando rodamos sem flags --status/--uninstall/--restore/--json
+# com TTY de verdade, mostramos um menu estilo OpenCode. Com --yes ou sem TTY, o
+# fluxo continua 100% por flags (comportamento atual).
+if [ "$MODE" = "install" ] && st_tui_is_interactive; then
+    st_choice="$(st_tui_menu "GoLiveBypass standalone" \
+        "Instalar / atualizar o bypass" \
+        "Ver status" \
+        "Desinstalar" \
+        "Sair")"
+    case "$st_choice" in
+        1) : ;;  # continua no fluxo de instalação abaixo
+        2) MODE="status"; JSON=0 ;;
+        3) MODE="uninstall" ;;
+        *) printf '  %sAte mais.%s\n' "$C_DIM" "$C_OFF"; exit 0 ;;
+    esac
+    # Se veio de "Ver status" ou "Desinstalar", despacha abaixo (code continua).
+fi
+
 aviso_empacotado
 FOUND="$(discord_dirs)"
 [ -n "$FOUND" ] || fail "Nao achei nenhum Discord instalado."
@@ -901,6 +1052,20 @@ injected=0
 # O while do pipe roda em subshell; o acumulador precisa ser um arquivo para o -eq valer.
 lista="$(mktemp)"
 tally="$(mktemp)"
+
+# Se entramos pela TUI (instalar sem flags), pergunta a rede antes de injetar.
+if [ "$MODE" = "install" ] && st_tui_is_interactive; then
+    st_net="$(st_tui_menu "Como o bypass vai sair?" \
+        "Tor automatico (recomendado, baixa e sobe sozinho)" \
+        "Proxy gratuita (escolhida e testada sozinha)" \
+        "Proxy minha (socks5://host:porta)")"
+    case "$st_net" in
+        2) PROXY="" ; TOR_MODE=0 ;;
+        3) PROXY="$(st_tui_input "Endereco da proxy")" ; TOR_MODE=0 ;;
+        *) TOR_MODE=1 ;;
+    esac
+fi
+
 printf '%s\n' "$FOUND" > "$lista"
 while IFS='|' read -r resources flav detect id; do
     state="$(injection_state "$resources")"


### PR DESCRIPTION
## O que faz

Apos o Tor automatico (PR #48, ja no main), esta branch traz:

### 1. TUI estilo OpenCode nos 4 instaladores
- **installer/golivebypass-installer.sh / .ps1**: menus (principal, destino, rede, persistencia, mod) viram TUI com caixas, `●/○`, navegacao por setas/Enter/Esc e **box centralizado** no terminal
- **standalone/golivebypass-standalone.sh / .ps1**: menu interativo (instalar/status/desinstalar/rede)
- **Sem TTY ou `--yes`**: comportamento atual (menus [1]/[2]/[3] ou flags) — automacao e CI intactos
- POSIX 100% nos .sh (stty+dd); mouse SGR on/off onde o terminal suporta

### 2. Report de bug automatico (issue abre sozinha no GitHub)
- Quando o instalador falha, monta diagnostico (versao, OS, cauda do log) **sanitizado** e POST na mesma API de bugs da GUI (`api.skyplaceia.com/bugs/v1/reports`) — a issue nasce no `bezumiya/GoLiveBypass` sem o usuario copiar nada
- Sanitizacao (espelha o redact.ts): credenciais em URL `user:***@`, tokens Discord `***`, query de gateway `<params>`, proxy salva `<proxy-pessoal>`
- **`--yes`/automacao**: nao spamma a API (testes CI ficam limpos)
- Erros de digitacao do usuario (ex.: proxy invalida) **nao** reportam

### 3. Correcoes descobertas testando no seu PC (Equibop)
- **Detecta Equibop/Vesktop/Legcord AUR** (`/usr/lib/equibop`, `/opt`, etc.) no instalador de plugin — antes: `Discord nao encontrado`
- **Bug real da TUI**: `[ condicao ] && var=x` retornava status 1 com `set -e` e o menu nunca era desenhado (ficava `\x1b[?1000h` e morria). Corrigido para `if...fi; return 0`
- `tui_is_interactive` exige so `[ -t 0 ]` (pty/emuladores onde stdout nao reporta tty)

## Validacao
- pty 30x100: menu renderiza centralizado (`[11;19H`), navegacao setas+Enter retorna indice correto
- E2E: fail() no standalone sh -> POST com `Authorization: Bearer` + body JSON sanitizado chegaram ao servidor fake
- Deteccao local: Equibop AUR aparece como `Discord instalado (2)`
- Suite POSIX 51 ok (2 falhas ksh/mksh pre-existentes); ps1 parse OK na VM Windows