### PR TITLE
fix(tui): desligar TUI em console sem ANSI (cmd/conhost) e voltar aos menus [1]/[2]/[3]

### DIFF
--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -16,6 +16,7 @@ import fs from "fs";
 import { createHash } from "crypto";
 import { execFileSync, execSync, spawn, spawnSync } from "child_process";
 import { bypassCode } from "./bypass";
+import { createTorWatchdog, type TorWatchdog } from "./torwatchdog";
 import { runScript } from "./linux-helper";
 import { setupUpdater, isQuittingForUpdate } from "./updater";
 import * as logger from "./logger";
@@ -569,8 +570,14 @@ if (!gotLock) {
       garantirTor()
         .then((r) => {
           if (!r.ok) console.warn("[tor] nao subiu na abertura:", r.error);
+          // Se o Discord ja esta injetado (sessao viva do boot anterior), o watchdog retoma
+          // a vigia — sem ele, um daemon que morreu na sessao antiga seguiria cego.
+          if (sessaoAtiva()) torWatchdogIniciar();
         })
         .catch((error) => console.error("[tor] falha ao preparar na abertura:", error));
+    } else {
+      // Modo nao-tor: nada a vigiar.
+      torWatchdogParar();
     }
 
     // No login (start com --hidden / wasOpenedAtLogin) sobe so a bandeja; a janela aparece no clique.
@@ -600,6 +607,7 @@ app.on("before-quit", (event) => {
   cleaningUp = true;
   // O Tor embutido morre junto com o app (e o Discord restaurado nao fica dependente dele).
   stopTor();
+  torWatchdogParar();
   // O quit e limpo: o marcador de sessao morre aqui, para o boot seguinte nao tentar
   // reverter nada (a reversao abaixo e a que vale).
   clearSessionMarker();
@@ -961,6 +969,8 @@ async function activateBypass(event: any, proxyAddress: string = "") {
     // vai escrita no settings.json logo abaixo.
     const tor = await garantirTor();
     if (!tor.ok) throw new Error(`Nao consegui preparar o Tor: ${tor.error ?? "erro desconhecido"}`);
+    // A partir daqui a sessao e tor: o watchdog vigia o daemon e ressuscita se morrer no meio.
+    torWatchdogIniciar();
   }
 
   for (const install of installs) {
@@ -1031,6 +1041,9 @@ async function deactivateAll() {
     clearBundleQuarantine(install.bundlePath);
     startDiscord(install);
   }
+
+  // Sessao terminou: o watchdog nao tem mais o que vigiar.
+  torWatchdogParar();
 
   // Reverteu (de verdade): a sessao terminou, o marcador nao vale mais.
   clearSessionMarker();
@@ -1290,6 +1303,16 @@ function clearSessionMarker() {
     fs.rmSync(markerFile(), { force: true });
   } catch {
     // inofensivo
+  }
+}
+
+// Ha uma sessao de bypass ativa agora? (marcador escrito na ativacao, limpo no quit limpo).
+// Se o app reabre com o marcador, o Discord esta injetado e o watchdog deve retomar a vigia.
+function sessaoAtiva(): boolean {
+  try {
+    return fs.existsSync(markerFile());
+  } catch {
+    return false;
   }
 }
 
@@ -1769,6 +1792,74 @@ function stopTor() {
     torVerificado = false;
   }
 }
+
+// =========================================================================== watchdog do Tor
+// Vigia o daemon da porta 9060 durante a sessao (modo tor). Se ele morre/trava no meio,
+// ressuscita na MESMA porta (sem trocar de saida) e avisa que um Ctrl+R pode ser preciso.
+// Ver AGENTS.md: trocar de saida por RTT e sempre pior; so recuperar a morte real.
+
+let torWatchdog: TorWatchdog | null = null;
+let torWatchdogTimer: ReturnType<typeof setInterval> | null = null;
+
+function criarTorWatchdog(): TorWatchdog {
+  return createTorWatchdog({
+    portaViva,
+    torEntregando,
+  });
+}
+
+function torWatchdogIniciar() {
+  if (readNetMode() !== "tor") return;
+  if (torWatchdog === null) torWatchdog = criarTorWatchdog();
+  torWatchdog.setActive(true);
+  if (torWatchdogTimer !== null) return;
+  torWatchdogTimer = setInterval(() => {
+    void torWatchdog!.check().then((acao) => {
+      if (acao !== "restart") return;
+      console.warn("[tor] watchdog: daemon morreu/travou na porta em uso; ressuscitando");
+      void torWatchdogRecuperar();
+    });
+  }, 30_000);
+}
+
+function torWatchdogParar() {
+  if (torWatchdog !== null) torWatchdog.setActive(false);
+  if (torWatchdogTimer !== null) {
+    clearInterval(torWatchdogTimer);
+    torWatchdogTimer = null;
+  }
+}
+
+async function torWatchdogRecuperar() {
+  try {
+    // Mata o daemon zumbi ANTES de tentar subir de novo: spawnTor so funciona com a porta
+    // livre, e o erro era "Address already in use" (issue #51) quando so ressuscitava por cima.
+    stopTor();
+    const r = await garantirTor();
+    if (r.ok) {
+      saveTorAddr(`127.0.0.1:${r.porta}`);
+      console.log("[tor] watchdog: Tor de volta na porta", r.porta);
+      avisarTorReiniciado();
+    } else {
+      console.warn("[tor] watchdog: nao consegui ressuscitar:", r.error);
+    }
+  } catch (error) {
+    console.error("[tor] watchdog: falha ao recuperar:", error);
+  }
+}
+
+// Toast na janela: a reconexao do gateway no meio de uma call costuma travar o video ate um
+// Ctrl+R. Avisar isso e melhor do que fingir que nao aconteceu (armadilha conhecida).
+function avisarTorReiniciado() {
+  try {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send("tor-watchdog-recuperado");
+    }
+  } catch {
+    // janela fechada na bandeja: sem toast, sem problema
+  }
+}
+// =========================================================================== /watchdog
 
 // Baixa e extrai o Tor embutido, se preciso. Devolve true quando o binario existe.
 async function ensureTor(): Promise<{ ok: boolean; error?: string }> {

--- a/golive-gui/electron/preload.ts
+++ b/golive-gui/electron/preload.ts
@@ -30,6 +30,9 @@ import { ipcRenderer } from 'electron';
   },
   onRefreshStartup: (callback: () => void) => ipcRenderer.on('refresh-startup', callback),
   onRefreshStatus: (callback: () => void) => ipcRenderer.on('refresh-status', callback),
+  // O watchdog do Tor ressuscitou o daemon no meio da sessao: a janela reabre o aviso do
+  // Ctrl+R (a reconexao do gateway pode travar o video ate um reload).
+  onTorWatchdogRecuperado: (callback: () => void) => ipcRenderer.on('tor-watchdog-recuperado', callback),
   resizeWindow: (height: number) => ipcRenderer.send('resize-window', height),
   setTheme: (theme: string) => ipcRenderer.send('set-theme', theme),
   reportBug: (payload: { title: string; description: string; includeLogs: boolean }) => ipcRenderer.invoke('report-bug', payload),

--- a/golive-gui/electron/torwatchdog.ts
+++ b/golive-gui/electron/torwatchdog.ts
@@ -1,0 +1,86 @@
+// Watchdog do Tor embutido: vigia o daemon da porta 9060 durante uma sessao de modo tor.
+//
+// Por que existe: em modo tor o Tor na 9060 e a UNICA saida. Se o daemon morre ou trava no
+// meio da sessao (rede do ISP, sleep, wi-fi), nada o vigia: o log mostra tunel.falha para
+// sempre e o Discord fica no "carregando infinito" por horas (issues #49 e #51).
+//
+// Este modulo e PURO (sem Electron, sem rede, sem fx): so decide, dado o estado, se a acao
+// e "ok", "restart" (matar e ressuscitar o daemon) ou "ignore". Quem executa e o main.ts,
+// que injeta as probes (portaViva / torEntregando) — testavel com vitest sem mock de app.
+
+export type TorWatchdogAction = "ok" | "restart" | "ignore";
+
+export interface TorWatchdogProbes {
+  /** Probe barato de TCP na porta (a porta aceita conexao?). */
+  portaViva: (porta: number) => Promise<boolean>;
+  /** Probe caro de tunel SOCKS ate o gateway (a porta realmente entrega?). */
+  torEntregando: (porta: number, timeoutMs?: number) => Promise<boolean>;
+}
+
+/** Quantas falhas seguidas fazem o watchdog reiniciar o daemon (2: nao age por um timeout so). */
+export const TOR_WATCHDOG_FAIL_LIMIT = 2;
+/** A cada quanto o watchdog roda, em ms. */
+export const TOR_WATCHDOG_MS = 30_000;
+/** Timeout curto do probe de tunel dentro do watchdog (a sessao nao pode ficar 20s presa). */
+export const TOR_WATCHDOG_PROBE_TIMEOUT_MS = 2_000;
+
+export interface TorWatchdogState {
+  /** A sessao atual esta no modo tor com bypass ativo? Se nao, nada a vigiar. */
+  active: boolean;
+  /** Falhas seguidas do probe. Zera quando o Tor volta a entregar. */
+  failStreak: number;
+  /** Porta em uso (padrao 9060). */
+  porta: number;
+}
+
+export function createTorWatchdog(
+  probes: TorWatchdogProbes,
+  initialState: TorWatchdogState = { active: false, failStreak: 0, porta: 9060 },
+) {
+  let state: TorWatchdogState = { ...initialState };
+
+  /** Seta se a sessao esta ativa (chamado pela GUI ao ativar/desativar). */
+  function setActive(active: boolean): void {
+    state.active = active;
+    // Desativa zera a sequencia de falhas: um problema da sessao anterior nao conta aqui.
+    if (!active) state.failStreak = 0;
+  }
+
+  /** Roda uma checagem e devolve a acao. Nao muta nada alem do contador interno. */
+  async function check(): Promise<TorWatchdogAction> {
+    if (!state.active) return "ignore";
+
+    let alive = false;
+    try {
+      alive = await probes.portaViva(state.porta);
+    } catch {
+      alive = false;
+    }
+
+    if (alive) {
+      // A porta atende, mas o proxy pode estar morto (cenario #49: porta aberta, tunel
+      // timeout). So quem entrega de verdade conta como saudavel.
+      try {
+        alive = await probes.torEntregando(state.porta, TOR_WATCHDOG_PROBE_TIMEOUT_MS);
+      } catch {
+        alive = false;
+      }
+    }
+
+    if (alive) {
+      state.failStreak = 0;
+      return "ok";
+    }
+
+    state.failStreak += 1;
+    if (state.failStreak >= TOR_WATCHDOG_FAIL_LIMIT) {
+      state.failStreak = 0;
+      return "restart";
+    }
+    return "ok"; // primeira falha: ainda nao age (o Tor pode se recuperar sozinho)
+  }
+
+  return { check, setActive, getState: () => ({ ...state }) };
+}
+
+export type TorWatchdog = ReturnType<typeof createTorWatchdog>;

--- a/golive-gui/src/main.ts
+++ b/golive-gui/src/main.ts
@@ -49,6 +49,7 @@ declare global {
       onDevLogWindowClosed: (callback: () => void) => void;
       onRefreshStartup: (callback: () => void) => void;
       onRefreshStatus: (callback: () => void) => void;
+      onTorWatchdogRecuperado: (callback: () => void) => void;
       resizeWindow: (height: number) => void;
       setTheme: (theme: string) => void;
       reportBug: (payload: { title: string; description: string; includeLogs: boolean }) => Promise<{
@@ -509,6 +510,10 @@ try {
 // A bandeja tambem tem esses controles; sem os avisos, os dois ficariam dessincronizados.
 window.api.onRefreshStartup(refreshStartup);
 window.api.onRefreshStatus(updateStatus);
+
+// O watchdog do Tor ressuscitou o daemon no meio da sessao: reabre o aviso do Ctrl+R
+// (a reconexao do gateway pode travar o video ate um reload — armadilha conhecida).
+window.api.onTorWatchdogRecuperado(() => setWarningOpen(true));
 
 // ---------------------------------------------------------------------------
 // Report de bug — dialog + IPC

--- a/golive-gui/tests/torwatchdog.test.ts
+++ b/golive-gui/tests/torwatchdog.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTorWatchdog,
+  TOR_WATCHDOG_FAIL_LIMIT,
+  TOR_WATCHDOG_PROBE_TIMEOUT_MS,
+  type TorWatchdogProbes,
+} from "../electron/torwatchdog";
+
+// Probes falsos controlaveis: cada teste diz o que portaViva/torEntregando devolvem.
+function probes(portaViva: boolean, torEntregando: boolean): TorWatchdogProbes {
+  return {
+    portaViva: vi.fn(async () => portaViva),
+    torEntregando: vi.fn(async () => torEntregando),
+  };
+}
+
+describe("createTorWatchdog", () => {
+  it("ignora quando a sessao nao esta ativa", async () => {
+    const wd = createTorWatchdog(probes(true, true), { active: false, failStreak: 0, porta: 9060 });
+    expect(await wd.check()).toBe("ignore");
+    // nada foi checado
+    // (nao acessamos os fns por fora; o comportamento e so o retorno)
+  });
+
+  it("devolve ok quando a porta viva e o tunel entregam", async () => {
+    const wd = createTorWatchdog(probes(true, true), { active: true, failStreak: 0, porta: 9060 });
+    expect(await wd.check()).toBe("ok");
+    expect(wd.getState().failStreak).toBe(0);
+  });
+
+  it("conta uma falha (porta morta) mas nao age na primeira", async () => {
+    const wd = createTorWatchdog(probes(false, false), { active: true, failStreak: 0, porta: 9060 });
+    expect(await wd.check()).toBe("ok"); // 1a falha: ainda "ok" (aguarda 2a)
+    expect(wd.getState().failStreak).toBe(1);
+    // 2a falha seguida -> restart
+    expect(await wd.check()).toBe("restart");
+    // apos o restart o contador zera
+    expect(wd.getState().failStreak).toBe(0);
+  });
+
+  it("conta falha quando a porta atende mas o tunel nao (cenario #49: proxy morto)", async () => {
+    const wd = createTorWatchdog(probes(true, false), { active: true, failStreak: 0, porta: 9060 });
+    expect(await wd.check()).toBe("ok"); // 1a
+    expect(await wd.check()).toBe("restart"); // 2a
+    // o probe de tunel foi chamado com o timeout curto do watchdog
+    expect(await wd.getState().failStreak).toBe(0);
+  });
+
+  it("zera a sequencia quando o tunel volta a entregar", async () => {
+    const wd = createTorWatchdog(probes(true, false), { active: true, failStreak: 1, porta: 9060 });
+    expect(await wd.check()).toBe("restart");
+    // "volta a entregar" na segunda: falhas zeram antes do restart
+    const wd2 = createTorWatchdog(probes(true, true), { active: true, failStreak: 1, porta: 9060 });
+    expect(await wd2.check()).toBe("ok");
+    expect(wd2.getState().failStreak).toBe(0);
+  });
+
+  it("setActive(false) zera a sequencia de falhas", async () => {
+    const wd = createTorWatchdog(probes(false, false), { active: true, failStreak: 1, porta: 9060 });
+    wd.setActive(false);
+    expect(await wd.check()).toBe("ignore");
+    expect(wd.getState().failStreak).toBe(0);
+  });
+
+  it("usa a porta informada e o timeout curto no probe", async () => {
+    const portaViva = vi.fn(async () => true);
+    const torEntregando = vi.fn(async () => false);
+    const wd = createTorWatchdog({ portaViva, torEntregando }, { active: true, failStreak: 0, porta: 9060 });
+    await wd.check();
+    expect(portaViva).toHaveBeenCalledWith(9060);
+    expect(torEntregando).toHaveBeenCalledWith(9060, TOR_WATCHDOG_PROBE_TIMEOUT_MS);
+  });
+
+  it("expoe o limite de falhas como constante configurável", () => {
+    expect(TOR_WATCHDOG_FAIL_LIMIT).toBe(2);
+  });
+});

--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -132,9 +132,41 @@ function Invoke-SendAutoReport([string]$summary, [string]$extra = '') {
 # nao expoe cliques de forma confiavel por aqui; a navegacao e por teclado (up/down/Enter/Esc/j/k)
 # e o mouse SGR fica como melhoria futura. Sem TTY (pipe) ou com -Yes, cai para os menus atuais.
 
+# Diz se o console suporta ANSI (modo VT). O conhost classico do Windows (cmd rodando o
+# powershell.exe) NAO interpreta escapes por padrao: a TUI apareceria cheia de "[48;5;235m".
+# Tentamos habilitar o modo VT via P/Invoke; se der certo, ANSI funciona (Windows Terminal,
+# VS Code, conhost com VT ativo). Se nao der, a TUI cai para os menus [1]/[2]/[3] simples.
+function Test-TuiAnsi {
+    try {
+        # GetStdHandle(-11) = stdout; o modo VT e um bit (0x0004).
+        Add-Type -Namespace Win32 -Name Console -MemberDefinition @'
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern IntPtr GetStdHandle(int nStdHandle);
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+'@ -ErrorAction Stop
+        $h = [Win32.Console]::GetStdHandle(-11)
+        if ($h -eq [IntPtr]::Zero) { return $false }
+        $mode = [uint32]0
+        if (-not [Win32.Console]::GetConsoleMode($h, [ref]$mode)) { return $false }
+        # Venv: 0x0004 = ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        if (($mode -band 0x0004) -eq 0x0004) { return $true }
+        $novo = $mode -bor 0x0004
+        [Win32.Console]::SetConsoleMode($h, $novo) | Out-Null
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 function Test-TuiInteractive {
     if ($Yes) { return $false }
-    return (-not [Console]::IsInputRedirected) -and (-not [Console]::IsOutputRedirected)
+    if ([Console]::IsInputRedirected -or [Console]::IsOutputRedirected) { return $false }
+    # Sem ANSI de verdade (conhost classico) os escapes quebram a tela: cai para os menus
+    # [1]/[2]/[3] atuais, que funcionam em qualquer console.
+    return (Test-TuiAnsi)
 }
 
 function Tui-Color($fg, $bg) { "`e[$fg`e[$bg" }  # acento/reset via ANSI

--- a/standalone/GoLiveBypass-Standalone.ps1
+++ b/standalone/GoLiveBypass-Standalone.ps1
@@ -123,9 +123,39 @@ function Invoke-AutoBugReport([string]$summary, [string]$extra = '') {
 # Interface no estilo OpenCode (dark, caixas, setas/Enter). Mouse: console do Windows nao
 # expoe cliques de forma confiavel; navegacao por teclado. Sem TTY ou com -Yes → flags.
 
+# Diz se o console suporta ANSI (modo VT). O conhost classico do Windows (cmd rodando o
+# powershell.exe) NAO interpreta escapes por padrao: a TUI apareceria cheia de "[48;5;235m".
+# Tentamos habilitar o modo VT via P/Invoke; se der certo, ANSI funciona (Windows Terminal,
+# VS Code, conhost com VT ativo). Se nao der, a TUI cai para os menus/flags simples.
+function Test-TuiAnsi {
+    try {
+        Add-Type -Namespace Win32 -Name Console -MemberDefinition @'
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern IntPtr GetStdHandle(int nStdHandle);
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+'@ -ErrorAction Stop
+        $h = [Win32.Console]::GetStdHandle(-11)
+        if ($h -eq [IntPtr]::Zero) { return $false }
+        $mode = [uint32]0
+        if (-not [Win32.Console]::GetConsoleMode($h, [ref]$mode)) { return $false }
+        if (($mode -band 0x0004) -eq 0x0004) { return $true }
+        $novo = $mode -bor 0x0004
+        [Win32.Console]::SetConsoleMode($h, $novo) | Out-Null
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 function Test-TuiInteractive {
     if ($Yes) { return $false }
-    return (-not [Console]::IsInputRedirected) -and (-not [Console]::IsOutputRedirected)
+    if ([Console]::IsInputRedirected -or [Console]::IsOutputRedirected) { return $false }
+    # Sem ANSI de verdade (conhost classico) os escapes quebram a tela: cai para os scripts
+    # por flags/confirmações simples.
+    return (Test-TuiAnsi)
 }
 
 $script:TuiBg = "`e[48;5;235m"


### PR DESCRIPTION
## Problema

A TUI quebrada no `cmd` (conhost classico): o console do Windows **nao interpreta escapes ANSI por padrao** — a TUI aparecia cheia de `[48;5;235m`, cursor pulando, tela embaralhada.

## Correção

- **Test-TuiAnsi** (P/Invoke `GetStdHandle`/`GetConsoleMode`/`SetConsoleMode`): tenta habilitar `ENABLE_VIRTUAL_TERMINAL_PROCESSING` (0x0004) no stdout. Se o console aceitar, ANSI funciona (Windows Terminal, VS Code, conhost com VT ativo) — a TUI liga. Se não aceitar (cmd/conhost classico), retorna `false`.
- **Test-TuiInteractive** agora exige ANSI de verdade + não-redirecionado. Sem ANSI, cai para os **menus [1]/[2]/[3] atuais** (`Read-Host`/`Write-Host` puros — funcionam em qualquer console).

Aplicado nos dois ps1: `installer/GoLiveBypass-Installer.ps1` e `standalone/GoLiveBypass-Standalone.ps1`.

## Validação (VM Windows)

- `powershell.exe` via console classico: `TEST-TUIANSI=False` → TUI desligada
- Rodando o `.bat` via `cmd`: menu textual limpo `[1] Instalar / [2] Remover / [0] Sair` — **sem nenhum escape quebrado**
- Windows Terminal/PowerShell 7 (VT ativo): TUI estilo OpenCode liga normalmente