### PR TITLE
fix(installer+standalone): parar de abrir issue para erros de uso

### DIFF
--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -125,6 +125,41 @@ function Invoke-SendAutoReport([string]$summary, [string]$extra = '') {
     Invoke-BugReport $summary $desc
 }
 
+# Test-ShouldReport <mensagem>: $false se a mensagem NAO deve abrir issue.
+# Mesmo espelho do should_report() do .sh: erros de uso (dependencia faltando,
+# CLI digitada errada, path errado, ferramenta externa quebrada) nao viram
+# issue. O resto (bug real) continua reportando.
+function Test-ShouldReport([string]$msg) {
+    # cancelamento e instrucoes de uso
+    if ($msg -eq 'Cancelado.') { return $false }
+    if ($msg -like 'O Discord nao fechou*') { return $false }
+    # input / uso do usuario
+    if ($msg -like 'Opcao desconhecida: *') { return $false }
+    if ($msg -like 'Formato invalido. Use socks5://*') { return $false }
+    if ($msg -like 'Endereco da proxy invalido*') { return $false }
+    if ($msg -like 'Nao consegui baixar *') { return $false }
+    # dependencia faltando (ambiente)
+    if ($msg -like 'Instale *') { return $false }
+    if ($msg -like 'O npm nao conseguiu instalar o pnpm*') { return $false }
+    if ($msg -like 'Nao consegui deixar o pnpm funcionando*') { return $false }
+    # path / checkout errado
+    if ($msg -like 'Nao encontrei o checkout do Equicord/Vencord*') { return $false }
+    if ($msg -like 'Nao achei *') { return $false }
+    if ($msg -like '*ja existe e nao parece um checkout*') { return $false }
+    if ($msg -like 'Nao achei o patcher *') { return $false }
+    if ($msg -like 'Nao achei nenhum Discord instalado*') { return $false }
+    # ferramenta externa (ambiente)
+    if ($msg -eq 'git clone falhou') { return $false }
+    if ($msg -eq 'pnpm install falhou') { return $false }
+    if ($msg -eq 'pnpm build falhou') { return $false }
+    if ($msg -eq 'pnpm inject falhou') { return $false }
+    # desinstalacao / elevacao parcial
+    if ($msg -like 'Nao consegui desinstalar de todos*') { return $false }
+    if ($msg -like 'NADA foi injetado*') { return $false }
+    # default: e bug, reporta
+    return $true
+}
+
 # =========================================================================== /Report de bugs
 
 # =========================================================================== TUI (PowerShell)
@@ -1313,8 +1348,8 @@ try {
     Write-Host '      Se for relatar, mande esta linha junto.' -ForegroundColor DarkGray
 
     # Report automatico (se nao for automacao): a issue abre no GitHub.
-    # Cancelar ou uma instrucao de uso (ex.: "feche o Discord") nao e bug: nao reporta.
-    if ($_.Exception.Message -notmatch '^Cancelado|^O Discord nao fechou') {
+    # Erros de uso (dependencia, CLI typo, path errado, ferramenta externa) nao viram issue.
+    if (Test-ShouldReport $_.Exception.Message) {
         Invoke-SendAutoReport "Falha no instalador GoLiveBypass: $($_.Exception.Message)" $_.Exception.Message
     }
     exit 1

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -78,17 +78,48 @@ fi
 step() { printf '  %s[*] %s%s\n' "$C_DIM" "$1" "$C_OFF" >&2; }
 ok()   { printf '  %s[OK] %s%s\n' "$C_GREEN" "$1" "$C_OFF" >&2; }
 warn() { printf '  %s[!] %s%s\n' "$C_YELLOW" "$1" "$C_OFF" >&2; }
+# should_report <mensagem>: 0 se a mensagem deve virar issue no GitHub, 1 se nao.
+# Tudo o que e "erro de uso" (dependencia faltando, CLI digitada errada, path
+# errado, ferramenta externa quebrada) cai aqui — NAO e bug do projeto. O resto
+# (bug real do instalador/bypass/patcher) continua abrindo issue como antes.
+should_report() {
+    case "$1" in
+        # --- cancelamento e instrucoes de uso ---
+        "Cancelado.") return 1 ;;
+        "O Discord nao fechou"*) return 1 ;;
+        # --- input / uso do usuario ---
+        "Opcao desconhecida: "*) return 1 ;;
+        "Formato invalido. Use socks5://"*) return 1 ;;
+        "Endereco da proxy invalido"*) return 1 ;;
+        "Nao consegui baixar "*) return 1 ;;
+        # --- dependencia faltando (ambiente) ---
+        "Instale "*) return 1 ;;
+        "O npm nao conseguiu instalar o pnpm"*) return 1 ;;
+        "Nao consegui deixar o pnpm funcionando"*) return 1 ;;
+        # --- path / checkout errado ---
+        "Nao encontrei o checkout do Equicord/Vencord"*) return 1 ;;
+        "Nao achei "*) return 1 ;;
+        *"ja existe e nao parece um checkout"*) return 1 ;;
+        "Nao achei o patcher "*) return 1 ;;
+        "Nao achei nenhum Discord instalado"*) return 1 ;;
+        # --- ferramenta externa (ambiente) ---
+        "git clone falhou") return 1 ;;
+        "pnpm install falhou") return 1 ;;
+        "pnpm build falhou") return 1 ;;
+        "pnpm inject falhou") return 1 ;;
+        # --- desinstalacao / elevacao parcial ---
+        "Nao consegui desinstalar de todos"*) return 1 ;;
+        "NADA foi injetado"*) return 1 ;;
+        # default: e bug, reporta
+        *) return 0 ;;
+    esac
+}
+
 fail() {
     printf '\n  %s[X] %s%s\n\n' "$C_RED" "$1" "$C_OFF" >&2
-    # Cancelar ou uma instrucao de uso (ex.: "feche o Discord") nao e bug: nao reporta.
-    case "$1" in
-        "Cancelado."|"O Discord nao fechou"*) ;; # sem report
-        *)
-            if [ "${REPORT_NO_AUTO:-0}" -eq 0 ]; then
-                report_error "Falha no instalador GoLiveBypass: $1" 2>&1 || true
-            fi
-            ;;
-    esac
+    if [ "${REPORT_NO_AUTO:-0}" -eq 0 ] && should_report "$1"; then
+        report_error "Falha no instalador GoLiveBypass: $1" 2>&1 || true
+    fi
     exit 1
 }
 

--- a/standalone/GoLiveBypass-Standalone.ps1
+++ b/standalone/GoLiveBypass-Standalone.ps1
@@ -104,8 +104,8 @@ function Invoke-SanitizeBug([string]$text) {
 }
 
 function Invoke-AutoBugReport([string]$summary, [string]$extra = '') {
-    # Cancelar ou uma instrucao de uso (ex.: "feche o Discord") nao e bug: nao reporta.
-    if ($extra -match '^Cancelado|^O Discord nao fechou') { return }
+    # Erros de uso (dependencia, CLI typo, path errado, ferramenta externa) nao viram issue.
+    if (-not (Test-ShouldReport $extra)) { return }
     # monta a descricao: extra + cauda do log (se existir)
     $logPath = Join-Path $InstallDir 'golivebypass.log'
     $tail = ''
@@ -115,6 +115,41 @@ function Invoke-AutoBugReport([string]$summary, [string]$extra = '') {
     if ($extra -or $tail) {
         Invoke-BugReport $summary ($extra + "`n`n--- log ---`n" + $tail)
     }
+}
+
+# Test-ShouldReport <mensagem>: $false se a mensagem NAO deve abrir issue.
+# Mesmo espelho do should_report() do .sh: erros de uso (dependencia faltando,
+# CLI digitada errada, path errado, ferramenta externa quebrada) nao viram
+# issue. O resto (bug real) continua reportando.
+function Test-ShouldReport([string]$msg) {
+    # cancelamento e instrucoes de uso
+    if ($msg -eq 'Cancelado.') { return $false }
+    if ($msg -like 'O Discord nao fechou*') { return $false }
+    # input / uso do usuario
+    if ($msg -like 'Opcao desconhecida: *') { return $false }
+    if ($msg -like 'Formato invalido. Use socks5://*') { return $false }
+    if ($msg -like 'Endereco da proxy invalido*') { return $false }
+    if ($msg -like 'Nao consegui baixar *') { return $false }
+    # dependencia faltando (ambiente)
+    if ($msg -like 'Instale *') { return $false }
+    if ($msg -like 'O npm nao conseguiu instalar o pnpm*') { return $false }
+    if ($msg -like 'Nao consegui deixar o pnpm funcionando*') { return $false }
+    # path / checkout errado
+    if ($msg -like 'Nao encontrei o checkout do Equicord/Vencord*') { return $false }
+    if ($msg -like 'Nao achei *') { return $false }
+    if ($msg -like '*ja existe e nao parece um checkout*') { return $false }
+    if ($msg -like 'Nao achei o patcher *') { return $false }
+    if ($msg -like 'Nao achei nenhum Discord instalado*') { return $false }
+    # ferramenta externa (ambiente)
+    if ($msg -eq 'git clone falhou') { return $false }
+    if ($msg -eq 'pnpm install falhou') { return $false }
+    if ($msg -eq 'pnpm build falhou') { return $false }
+    if ($msg -eq 'pnpm inject falhou') { return $false }
+    # desinstalacao / elevacao parcial
+    if ($msg -like 'Nao consegui desinstalar de todos*') { return $false }
+    if ($msg -like 'NADA foi injetado*') { return $false }
+    # default: e bug, reporta
+    return $true
 }
 
 # =========================================================================== /Report de bugs

--- a/standalone/golivebypass-standalone.sh
+++ b/standalone/golivebypass-standalone.sh
@@ -84,18 +84,48 @@ C_OFF=$(printf '\033[0m'); C_CYAN=$(printf '\033[36m'); C_GREEN=$(printf '\033[3
 step() { printf '  %s[*]%s %s\n' "$C_CYAN" "$C_OFF" "$1" >&2; }
 ok()   { printf '  %s[OK]%s %s\n' "$C_GREEN" "$C_OFF" "$1" >&2; }
 warn() { printf '  %s[!]%s %s\n' "$C_YELLOW" "$C_OFF" "$1" >&2; }
+# should_report <mensagem>: 0 se a mensagem deve virar issue no GitHub, 1 se nao.
+# Mesmo do instalador de plugin: erros de uso (dependencia, CLI typo, path
+# errado, ferramenta externa quebrada) nao viram issue. Bug real continua.
+should_report() {
+    case "$1" in
+        # --- cancelamento e instrucoes de uso ---
+        "Cancelado.") return 1 ;;
+        "O Discord nao fechou"*) return 1 ;;
+        # --- input / uso do usuario ---
+        "Opcao desconhecida: "*) return 1 ;;
+        "Formato invalido. Use socks5://"*) return 1 ;;
+        "Endereco da proxy invalido"*) return 1 ;;
+        "Nao consegui baixar "*) return 1 ;;
+        # --- dependencia faltando (ambiente) ---
+        "Instale "*) return 1 ;;
+        "O npm nao conseguiu instalar o pnpm"*) return 1 ;;
+        "Nao consegui deixar o pnpm funcionando"*) return 1 ;;
+        # --- path / checkout errado ---
+        "Nao encontrei o checkout do Equicord/Vencord"*) return 1 ;;
+        "Nao achei "*) return 1 ;;
+        *"ja existe e nao parece um checkout"*) return 1 ;;
+        "Nao achei o patcher "*) return 1 ;;
+        "Nao achei nenhum Discord instalado"*) return 1 ;;
+        # --- ferramenta externa (ambiente) ---
+        "git clone falhou") return 1 ;;
+        "pnpm install falhou") return 1 ;;
+        "pnpm build falhou") return 1 ;;
+        "pnpm inject falhou") return 1 ;;
+        # --- desinstalacao / elevacao parcial ---
+        "Nao consegui desinstalar de todos"*) return 1 ;;
+        "NADA foi injetado"*) return 1 ;;
+        # default: e bug, reporta
+        *) return 0 ;;
+    esac
+}
+
 fail() {
     printf '  %s[X]%s %s\n' "$C_RED" "$C_OFF" "$1" >&2
-    # Cancelar ou uma instrucao de uso (ex.: "feche o Discord") nao e bug: nao reporta.
-    case "$1" in
-        "Cancelado."|"O Discord nao fechou"*) ;; # sem report
-        *)
-            # Report automatico: so quando esta de fato falhando (e nao em --yes de teste).
-            if [ "${REPORT_NO_AUTO:-0}" -eq 0 ]; then
-                report_error "Falha no instalador GoLiveBypass: $1" 2>&1 || true
-            fi
-            ;;
-    esac
+    # Report automatico: so quando esta de fato falhando (e nao em --yes de teste).
+    if [ "${REPORT_NO_AUTO:-0}" -eq 0 ] && should_report "$1"; then
+        report_error "Falha no instalador GoLiveBypass: $1" 2>&1 || true
+    fi
     exit 1
 }
 


### PR DESCRIPTION
O auto-report dos instaladores/standalone so filtrava 2 strings (Cancelado. e O Discord nao fechou). Todo o resto virava issue, incluindo dependencias faltando, CLI digitada errada, path errado e ferramenta externa quebrada - nenhum desses e bug do projeto.

Resultado: 5 issues desnecessarias abertas hoje (#65-#69), alem de outras acumuladas.

Adiciona should_report() (sh) e Test-ShouldReport (ps1) com deny-list explicita de 22 padroes de mensagem de uso, espelhadas nos 4 scripts. Bug real (bypass/patcher/instalador) continua reportando.

Filtrados (NAO viram issue):
- Cancelamento / instrucoes de uso
- Input do usuario: proxy format errado, CLI typo, falha de download
- Dependencia faltando: Node, pnpm, git
- Path / checkout errado: `Nao encontrei o checkout...`, Discord nao instalado
- Ferramenta externa quebrada: git clone, pnpm install/build/inject
- Falha de desinstalacao / elevacao parcial

Nao-objetivos (deixados pra depois):
- Dedup client-side (cache de hashes)
- Opt-out (`--no-bug-report`)
- Consentimento antes de enviar