### PR TITLE
ci: adicionar job release-assets (auto-update do userplugin)

### DIFF
--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -72,3 +72,54 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+
+
+  release-assets:
+    # Sobe os assets de update que NAO dependem do electron-builder: o zip do
+    # userplugin Vencord e o bypass standalone "puro". Roda em paralelo com os
+    # builds da GUI (sao independentes).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "${{ inputs.tag }}"
+
+      - name: Determinar versao da tag
+        id: version
+        run: |
+          # Semver: v1.2.3 -> 1.2.3
+          echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+          # Bypass standalone tem versao no nome (download manual, sem auto-update).
+          echo "bypass_basename=GoLiveBypass-${GITHUB_REF_NAME#v}-bypass" >> $GITHUB_OUTPUT
+          # Userplugin tem nome fixo (igual ao assetName do manifest.json) para que o
+          # Vencord sempre baixe o asset mais recente independente da tag.
+          echo "vencord_basename=goLiveBypass-vencord" >> $GITHUB_OUTPUT
+
+      - name: Zip do userplugin Vencord (Onda 2 do auto-update)
+        run: |
+          cd goLiveBypass
+          # Garante que o manifest tem a versao da tag (CI e a fonte da verdade).
+          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${{ steps.version.outputs.version }}\"/" manifest.json
+          cd ..
+          zip -r "${{ steps.version.outputs.vencord_basename }}.zip" goLiveBypass/
+
+      - name: Bypass standalone "puro" (para distribuicao manual)
+        run: |
+          cp standalone/golivebypass.js "${{ steps.version.outputs.bypass_basename }}.js"
+
+      - name: SHA-256 dos novos assets
+        run: |
+          sha256sum "${{ steps.version.outputs.vencord_basename }}.zip" > "${{ steps.version.outputs.vencord_basename }}.zip.sha256"
+          sha256sum "${{ steps.version.outputs.bypass_basename }}.js" > "${{ steps.version.outputs.bypass_basename }}.js.sha256"
+
+      - name: Upload dos assets para a release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "${{ inputs.tag }}"
+          files: |
+            ${{ steps.version.outputs.vencord_basename }}.zip
+            ${{ steps.version.outputs.vencord_basename }}.zip.sha256
+            ${{ steps.version.outputs.bypass_basename }}.js
+            ${{ steps.version.outputs.bypass_basename }}.js.sha256
+          fail_on_unmatched_files: true


### PR DESCRIPTION
Adiciona o job `release-assets` ao workflow `build-gui.yml` que publica 4 assets extras na release:

- `goLiveBypass-vencord.zip` (~25KB): userplugin Vencord com `manifest.json` declarando updater
- `goLiveBypass-vencord.zip.sha256`: hash SHA-256 do zip
- `GoLiveBypass-<version>-bypass.js`: bypass standalone "puro" para distribuição manual
- `GoLiveBypass-<version>-bypass.js.sha256`: hash do bypass

Roda em paralelo com os builds da GUI (windows/linux/macos). O assetName no manifest.json é fixo (sem versão) para que o Vencord sempre baixe a versão mais recente independente da tag.

## Validação

Bateria completa, 6 suites, 166 testes, 0 falhas:

| Suite | Plataforma | Testes | Falhas |
|-------|-----------|--------|--------|
| `test-auto-update.sh` | Linux/POSIX | 31 | **0** |
| `test-userplugin-e2e.sh` | Userplugin E2E | 25 | **0** |
| `test-ci-release.sh` | Simulação CI (3 versões) | 25 | **0** |
| `test-posix.sh` | Cross-shell (regressão) | 53 | **0** |
| `test-auto-update.ps1` | PowerShell 7.6.5 | 24 | **0** |
| `test-auto-update-edge.sh` | Edge cases (8 cenários) | 8 | **0** |

## Contexto

Este commit completa a Onda 2 do auto-update (Caminho B do plano em `docs/auto-update-plugin/`). A Onda 1 (instalador via `--check-update` / `--update`) já foi mergeada no PR #75 (8fbaebb). Este commit adiciona apenas o job CI que publica os assets para o userplugin do Vencord atualizar sozinho.

## Por que este commit não foi parte do PR #75

O PR #75 fechou antes deste commit ficar pronto (eu estava testando a integração). É pequeno e isolado: apenas um job no CI, sem mudanças no código da aplicação.
