### PR TITLE
fix(installer+standalone): filtrar "Ctrl+C cancelou" do auto-report

### DIFF
--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -134,6 +134,12 @@ function Invoke-SendAutoReport([string]$summary, [string]$extra = '') {
 function Test-ShouldReport([string]$msg) {
     # cancelamento e instrucoes de uso
     if ($msg -eq 'Cancelado.') { return $false }
+    # Cancelamento via Ctrl+C no Read-Host: PowerShell lanca a mensagem nativa
+    # "Esse comando nao pode ser executado devido ao erro: A operacao foi cancelada
+    # pelo usuario." (PT-BR) / "This command cannot be executed ... The operation
+    # was canceled by the user." (EN). E cancelamento do usuario, nao bug.
+    if ($msg -like '*cancelada pelo usu*rio*') { return $false }
+    if ($msg -like '*canceled by the user*') { return $false }
     if ($msg -like 'O Discord nao fechou*') { return $false }
     # input / uso do usuario
     if ($msg -like 'Opcao desconhecida: *') { return $false }

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -88,6 +88,13 @@ should_report() {
     case "$1" in
         # --- cancelamento e instrucoes de uso ---
         "Cancelado.") return 1 ;;
+        # Cancelamento via Ctrl+C: bash imprime "^C" mas o erro que captura o
+        # catch do sh vem do comando interrompido ("interrompido", "terminated"
+        # ou "canceled" dependendo do shell).
+        *"cancelada pelo usu"*) return 1 ;;
+        *"canceled by the user"*) return 1 ;;
+        *"interrompido"*) return 1 ;;
+        *"terminated"*) return 1 ;;
         "O Discord nao fechou"*) return 1 ;;
         # --- input / uso do usuario ---
         "Opcao desconhecida: "*) return 1 ;;

--- a/standalone/GoLiveBypass-Standalone.ps1
+++ b/standalone/GoLiveBypass-Standalone.ps1
@@ -124,6 +124,9 @@ function Invoke-AutoBugReport([string]$summary, [string]$extra = '') {
 function Test-ShouldReport([string]$msg) {
     # cancelamento e instrucoes de uso
     if ($msg -eq 'Cancelado.') { return $false }
+    # Cancelamento via Ctrl+C no Read-Host: ver nota no installer.ps1.
+    if ($msg -like '*cancelada pelo usu*rio*') { return $false }
+    if ($msg -like '*canceled by the user*') { return $false }
     if ($msg -like 'O Discord nao fechou*') { return $false }
     # input / uso do usuario
     if ($msg -like 'Opcao desconhecida: *') { return $false }

--- a/standalone/golivebypass-standalone.sh
+++ b/standalone/golivebypass-standalone.sh
@@ -91,6 +91,11 @@ should_report() {
     case "$1" in
         # --- cancelamento e instrucoes de uso ---
         "Cancelado.") return 1 ;;
+        # Cancelamento via Ctrl+C: ver nota no installer.sh.
+        *"cancelada pelo usu"*) return 1 ;;
+        *"canceled by the user"*) return 1 ;;
+        *"interrompido"*) return 1 ;;
+        *"terminated"*) return 1 ;;
         "O Discord nao fechou"*) return 1 ;;
         # --- input / uso do usuario ---
         "Opcao desconhecida: "*) return 1 ;;


### PR DESCRIPTION
## Problema

Quando o usuário apertava **Ctrl+C** num "Pode seguir? [s/N]:" do instalador (ou de qualquer `Confirm-Action` que usa `Read-Host`), o PowerShell lançava a exceção nativa:

> "Esse comando não pode ser executado devido ao erro: A operação foi cancelada pelo usuário."

A mensagem **não era filtrada** pelo `Test-ShouldReport` (que só filtrava `"Cancelado."`, o `throw` do `Tui-Menu` no Esc). O catch genérico do instalador abria issue automática tipo **#78** toda vez que alguém desistia de uma confirmação — o que é **cancelamento do usuário, não bug**.

## Fix

Adicionar 4 patterns a `Test-ShouldReport` (ps1) e `should_report` (sh) dos 4 instaladores, cobrindo as variantes mais prováveis da mensagem nativa:

- `ps1`: `"cancelada pelo usu*rio"` (PT-BR) e `"canceled by the user"` (EN)
- `sh`: mesmos 2 + `"interrompido"` e `"terminated"` (bash/ksh/dash respondem com palavras diferentes)

## Validação

- `tests/tui-windows/` rodando na VM 192.168.122.198: 10/10 testes continuam passando
- Cenário Ctrl+C no "Pode seguir?": instalador agora encerra silenciosamente, **sem report de bug**
- Reproduzi o bug e confirmei o fix em ambos os estados (com e sem o filtro)

## Arquivos

- `installer/GoLiveBypass-Installer.ps1` — 6 inserções
- `installer/golivebypass-installer.sh` — 7 inserções
- `standalone/GoLiveBypass-Standalone.ps1` — 3 inserções
- `standalone/golivebypass-standalone.sh` — 5 inserções

(Os 4 têm a mesma mudança: 2-4 patterns novos no início da deny-list do `Test-ShouldReport` / `should_report`.)
