### PR TITLE
feat(gui): exibir versão instalada e opção para silenciar notificações de atualização

### DIFF
--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -397,6 +397,7 @@ function showWindow() {
     mainWindow.focus();
     // A bandeja pode ter mudado o startup ou o status com a janela escondida; ao reaparecer, sincroniza.
     mainWindow.webContents.send("refresh-startup");
+    mainWindow.webContents.send("refresh-auto-update");
     refreshWindowStatus();
   } else {
     createWindow();
@@ -439,6 +440,17 @@ async function refreshTray() {
           type: "checkbox",
           checked: getStartup(),
           click: (item) => setStartup(item.checked),
+        },
+        {
+          label: "Avisar sobre atualizações",
+          type: "checkbox",
+          checked: readAutoUpdate(),
+          click: (item) => {
+            saveAutoUpdate(item.checked);
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send("refresh-auto-update");
+            }
+          },
         },
         { type: "separator" },
         // Sair pela bandeja / barra de menus reverte so o que e nosso.
@@ -590,7 +602,7 @@ if (!gotLock) {
     app.on("activate", showWindow);
     // Checa por atualizacao na release do GitHub (Windows portable: baixa e substitui;
     // Mac/Linux: autoUpdater nativo). Roda sozinho e em silencio se nao houver nada.
-    setupUpdater(() => mainWindow);
+    setupUpdater(() => mainWindow, () => readAutoUpdate());
   });
 }
 
@@ -2129,7 +2141,37 @@ function readNetMode(): string {
   }
 }
 
+export function saveAutoUpdate(enabled: boolean) {
+  try {
+    const dir = settingsDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, "settings.json");
+    const atual = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, "utf8")) : {};
+    fs.writeFileSync(file, JSON.stringify({ ...atual, autoUpdate: enabled }, null, 4));
+  } catch (error) {
+    console.error("[settings] nao consegui salvar preferencia de atualizacao:", error);
+  }
+}
+
+export function readAutoUpdate(): boolean {
+  try {
+    const file = path.join(settingsDir(), "settings.json");
+    if (!fs.existsSync(file)) return true;
+    const data = JSON.parse(fs.readFileSync(file, "utf8"));
+    return typeof data.autoUpdate === "boolean" ? data.autoUpdate : true;
+  } catch {
+    return true;
+  }
+}
+
 // Detecta Tor disponivel: o embutido (porta dedicada) ou um Tor do sistema (portas classicas).
+
+// IPC de autoUpdate
+ipcMain.handle("get-auto-update", () => readAutoUpdate());
+ipcMain.handle("set-auto-update", (_event, enabled: unknown) => {
+  saveAutoUpdate(enabled !== false);
+  refreshTray().catch(() => {});
+});
 
 // IPC do modo de rede + Tor embutido.
 ipcMain.handle("get-net-mode", () => readNetMode());

--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -274,6 +274,7 @@ function createWindow() {
   // Sem isto, um link com target="_blank" abre numa janela do Electron sem barra de endereco:
   // a pessoa nao ve para onde esta indo, e nao tem como voltar. Vale para o botao do Discord,
   // que ja existia, e para os creditos.
+  mainWindow.setTitle(`GoLiveBypass v${app.getVersion()}`);
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (/^https:\/\//.test(url)) void shell.openExternal(url);
     return { action: "deny" };
@@ -422,10 +423,10 @@ async function refreshTray() {
     const status = IS_LINUX ? await linuxStatus() : getStatus();
     cachedStatus = status;
     const label = statusLabel(status);
-    tray.setToolTip(`GoLiveBypass — ${label}`);
+    tray.setToolTip(`GoLiveBypass v${app.getVersion()} — ${label}`);
     tray.setContextMenu(
       Menu.buildFromTemplate([
-        { label: `GoLiveBypass — ${label}`, enabled: false },
+        { label: `GoLiveBypass v${app.getVersion()} — ${label}`, enabled: false },
         { type: "separator" },
         { label: "Abrir", click: showWindow },
         {
@@ -1343,6 +1344,7 @@ ipcMain.handle("deactivate", async (event) => {
   refreshTray().catch(() => {});
 });
 ipcMain.handle("get-platform", () => (IS_LINUX ? "linux" : isMac ? "mac" : "windows"));
+ipcMain.handle("get-app-version", () => app.getVersion());
 ipcMain.handle("get-status", async () => {
   if (IS_LINUX) return linuxStatus();
   return getStatus();

--- a/golive-gui/electron/preload.ts
+++ b/golive-gui/electron/preload.ts
@@ -7,6 +7,7 @@ import { ipcRenderer } from 'electron';
   deactivate: () => ipcRenderer.invoke('deactivate'),
   getStatus: () => ipcRenderer.invoke('get-status'),
   getProxy: () => ipcRenderer.invoke('get-proxy'),
+  getVersion: () => ipcRenderer.invoke('get-app-version'),
   getPlatform: () => ipcRenderer.invoke('get-platform'),
   getStartup: () => ipcRenderer.invoke('get-startup'),
   setStartup: (enabled: boolean) => ipcRenderer.invoke('set-startup', enabled),

--- a/golive-gui/electron/preload.ts
+++ b/golive-gui/electron/preload.ts
@@ -11,6 +11,8 @@ import { ipcRenderer } from 'electron';
   getPlatform: () => ipcRenderer.invoke('get-platform'),
   getStartup: () => ipcRenderer.invoke('get-startup'),
   setStartup: (enabled: boolean) => ipcRenderer.invoke('set-startup', enabled),
+  getAutoUpdate: () => ipcRenderer.invoke('get-auto-update'),
+  setAutoUpdate: (enabled: boolean) => ipcRenderer.invoke('set-auto-update', enabled),
   getNetMode: () => ipcRenderer.invoke('get-net-mode'),
   setNetMode: (mode: string) => ipcRenderer.invoke('set-net-mode', mode),
   getTorStatus: () => ipcRenderer.invoke('get-tor-status'),
@@ -31,6 +33,7 @@ import { ipcRenderer } from 'electron';
     ipcRenderer.on('dev-log-window-closed', () => callback());
   },
   onRefreshStartup: (callback: () => void) => ipcRenderer.on('refresh-startup', callback),
+  onRefreshAutoUpdate: (callback: () => void) => ipcRenderer.on('refresh-auto-update', callback),
   onRefreshStatus: (callback: () => void) => ipcRenderer.on('refresh-status', callback),
   // O watchdog do Tor ressuscitou o daemon no meio da sessao: a janela reabre o aviso do
   // Ctrl+R (a reconexao do gateway pode travar o video ate um reload).

--- a/golive-gui/electron/updater.ts
+++ b/golive-gui/electron/updater.ts
@@ -212,7 +212,10 @@ export function isQuittingForUpdate() {
 
 // ------------------------------------------------------------------ API publica
 
-export function setupUpdater(getMainWindow: () => BrowserWindow | null) {
+export function setupUpdater(
+  getMainWindow: () => BrowserWindow | null,
+  isAutoUpdateEnabled: () => boolean = () => true,
+) {
   // Dev (npm run dev): o app roda fora do pacote, sem o app-update.yml embutido.
   // O electron-updater usa o dev-app-update.yml na raiz do projeto + esta flag.
   const isDev = !app.isPackaged;
@@ -243,6 +246,7 @@ export function setupUpdater(getMainWindow: () => BrowserWindow | null) {
     // O download corre sozinho em background; ao terminar, avisa o usuario e
     // so instala com o OK dele — atualizar sem avisar derruba o app na hora.
     autoUpdater.on("update-downloaded", (info) => {
+      if (!isAutoUpdateEnabled()) return;
       updateReady = true;
       const win = getMainWindow();
       const choice = win
@@ -267,17 +271,23 @@ export function setupUpdater(getMainWindow: () => BrowserWindow | null) {
       }
     });
 
-    autoUpdater.checkForUpdatesAndNotify().catch(() => {});
+    if (isAutoUpdateEnabled()) {
+      autoUpdater.checkForUpdatesAndNotify().catch(() => {});
+    }
     return;
   }
 
   // Windows portable: checagem periodica em background.
-  setInterval(() => void checkWindowsUpdate(getMainWindow), CHECK_INTERVAL_MS);
-  void checkWindowsUpdate(getMainWindow);
+  setInterval(() => void checkWindowsUpdate(getMainWindow, isAutoUpdateEnabled), CHECK_INTERVAL_MS);
+  void checkWindowsUpdate(getMainWindow, isAutoUpdateEnabled);
 }
 
-async function checkWindowsUpdate(getMainWindow: () => BrowserWindow | null) {
+export async function checkWindowsUpdate(
+  getMainWindow: () => BrowserWindow | null,
+  isAutoUpdateEnabled: () => boolean = () => true,
+) {
   if (checking || updateReady) return;
+  if (!isAutoUpdateEnabled()) return;
   if (Date.now() - lastCheckAt < 60_000) return; // no minimo 1min entre checagens
   checking = true;
   lastCheckAt = Date.now();

--- a/golive-gui/index.html
+++ b/golive-gui/index.html
@@ -36,7 +36,7 @@
                 />
                 GoLiveBypass
               </span>
-              <span class="meta">Go Live &middot; Brasil</span>
+              <span class="meta">Go Live &middot; Brasil &middot; <span id="appVersion"></span></span>
             </div>
           </div>
 

--- a/golive-gui/index.html
+++ b/golive-gui/index.html
@@ -200,6 +200,14 @@
           <span id="startupLabel">Iniciar com o Windows</span>
         </label>
 
+        <label class="switch-row" id="autoUpdateRow">
+          <input type="checkbox" id="autoUpdateToggle" checked />
+          <span class="switch-track" aria-hidden="true">
+            <span class="switch-thumb"></span>
+          </span>
+          <span id="autoUpdateLabel">Avisar sobre atualizações</span>
+        </label>
+
         <div class="net-mode-group">
           <div
             class="segmented"

--- a/golive-gui/package-lock.json
+++ b/golive-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "golive-gui",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "golive-gui",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "dependencies": {
         "electron-updater": "^6.8.9"
       },

--- a/golive-gui/src/main.ts
+++ b/golive-gui/src/main.ts
@@ -12,6 +12,8 @@ declare global {
       getPlatform: () => Promise<string>;
       getStartup: () => Promise<boolean>;
       setStartup: (enabled: boolean) => Promise<void>;
+      getAutoUpdate: () => Promise<boolean>;
+      setAutoUpdate: (enabled: boolean) => Promise<void>;
       getNetMode: () => Promise<string>;
       setNetMode: (mode: string) => Promise<string>;
       getTorStatus: () => Promise<{ presente: boolean; ativo: boolean; porta: number }>;
@@ -49,6 +51,7 @@ declare global {
       onLogChunk: (callback: (chunk: string) => void) => void;
       onDevLogWindowClosed: (callback: () => void) => void;
       onRefreshStartup: (callback: () => void) => void;
+      onRefreshAutoUpdate: (callback: () => void) => void;
       onRefreshStatus: (callback: () => void) => void;
       onTorWatchdogRecuperado: (callback: () => void) => void;
       resizeWindow: (height: number) => void;
@@ -142,6 +145,7 @@ const toastClose = document.getElementById('toastClose') as HTMLButtonElement | 
 const appVersionEl = document.getElementById('appVersion');
 const proxyInput = document.getElementById('proxyInput') as HTMLInputElement;
 const startupToggle = document.getElementById('startupToggle') as HTMLInputElement;
+const autoUpdateToggle = document.getElementById('autoUpdateToggle') as HTMLInputElement | null;
 const themeBtn = document.getElementById('themeBtn') as HTMLButtonElement;
 
 let currentState = 'INACTIVE';
@@ -354,6 +358,7 @@ initTheme();
 refreshVersion();
 updateStatus();
 refreshStartup();
+refreshAutoUpdate();
 refreshProxy();
 refreshNetMode();
 refreshTorStatus();
@@ -376,6 +381,16 @@ async function refreshVersion() {
 async function refreshStartup() {
   try {
     startupToggle.checked = await window.api.getStartup();
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+async function refreshAutoUpdate() {
+  try {
+    if (autoUpdateToggle) {
+      autoUpdateToggle.checked = await window.api.getAutoUpdate();
+    }
   } catch (err) {
     console.error(err);
   }
@@ -551,6 +566,14 @@ if (vpsGuide) {
 startupToggle.addEventListener('change', async () => {
   await window.api.setStartup(startupToggle.checked);
 });
+
+autoUpdateToggle?.addEventListener('change', async () => {
+  if (autoUpdateToggle) {
+    await window.api.setAutoUpdate(autoUpdateToggle.checked);
+  }
+});
+
+window.api.onRefreshAutoUpdate?.(refreshAutoUpdate);
 
 // ---------------------------------------------------------------------------
 // Modo desenvolvedor: so o toggle aqui. Logs e report ficam numa janela aparte.

--- a/golive-gui/src/main.ts
+++ b/golive-gui/src/main.ts
@@ -8,6 +8,7 @@ declare global {
       deactivate: () => Promise<void>;
       getStatus: () => Promise<string>;
       getProxy: () => Promise<string>;
+      getVersion: () => Promise<string>;
       getPlatform: () => Promise<string>;
       getStartup: () => Promise<boolean>;
       setStartup: (enabled: boolean) => Promise<void>;
@@ -138,6 +139,7 @@ const conflictOverwriteBtn = document.getElementById('conflictOverwriteBtn') as 
 let detectedMod: string | null = null;
 const warningToast = document.getElementById('warningToast') as HTMLElement | null;
 const toastClose = document.getElementById('toastClose') as HTMLButtonElement | null;
+const appVersionEl = document.getElementById('appVersion');
 const proxyInput = document.getElementById('proxyInput') as HTMLInputElement;
 const startupToggle = document.getElementById('startupToggle') as HTMLInputElement;
 const themeBtn = document.getElementById('themeBtn') as HTMLButtonElement;
@@ -349,6 +351,7 @@ conflictOverwriteBtn?.addEventListener('click', async () => {
 // Inicialização
 applyPlatformCopy();
 initTheme();
+refreshVersion();
 updateStatus();
 refreshStartup();
 refreshProxy();
@@ -358,6 +361,17 @@ refreshTorStatus();
 // congela no que era verdade quando a janela abriu. A checagem custa um connect no loopback.
 setInterval(refreshTorStatus, 5000);
 fitWindowToContent();
+
+async function refreshVersion() {
+  try {
+    const ver = await window.api.getVersion();
+    if (appVersionEl && ver) {
+      appVersionEl.textContent = `v${ver}`;
+    }
+  } catch (err) {
+    console.error(err);
+  }
+}
 
 async function refreshStartup() {
   try {

--- a/golive-gui/tests/updater-settings.test.ts
+++ b/golive-gui/tests/updater-settings.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+describe("updater-settings", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "golive-updater-test-"));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ok
+    }
+  });
+
+  function readAutoUpdateFrom(dir: string): boolean {
+    try {
+      const file = path.join(dir, "settings.json");
+      if (!fs.existsSync(file)) return true;
+      const data = JSON.parse(fs.readFileSync(file, "utf8"));
+      return typeof data.autoUpdate === "boolean" ? data.autoUpdate : true;
+    } catch {
+      return true;
+    }
+  }
+
+  function saveAutoUpdateTo(dir: string, enabled: boolean) {
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      const file = path.join(dir, "settings.json");
+      const atual = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, "utf8")) : {};
+      fs.writeFileSync(file, JSON.stringify({ ...atual, autoUpdate: enabled }, null, 4));
+    } catch (error) {
+      console.error("[settings] nao consegui salvar preferencia de atualizacao:", error);
+    }
+  }
+
+  it("retorna true por padrao quando settings.json nao existe", () => {
+    expect(readAutoUpdateFrom(tempDir)).toBe(true);
+  });
+
+  it("salva false e recupera corretamente", () => {
+    saveAutoUpdateTo(tempDir, false);
+    expect(readAutoUpdateFrom(tempDir)).toBe(false);
+
+    const data = JSON.parse(fs.readFileSync(path.join(tempDir, "settings.json"), "utf8"));
+    expect(data.autoUpdate).toBe(false);
+  });
+
+  it("salva true e recupera corretamente", () => {
+    saveAutoUpdateTo(tempDir, false);
+    expect(readAutoUpdateFrom(tempDir)).toBe(false);
+
+    saveAutoUpdateTo(tempDir, true);
+    expect(readAutoUpdateFrom(tempDir)).toBe(true);
+  });
+
+  it("preserva configuracoes existentes (proxy, routeMode) ao alterar autoUpdate", () => {
+    const file = path.join(tempDir, "settings.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ proxy: "socks5://127.0.0.1:1080", routeMode: "free" }, null, 4),
+    );
+
+    saveAutoUpdateTo(tempDir, false);
+
+    const data = JSON.parse(fs.readFileSync(file, "utf8"));
+    expect(data.proxy).toBe("socks5://127.0.0.1:1080");
+    expect(data.routeMode).toBe("free");
+    expect(data.autoUpdate).toBe(false);
+    expect(readAutoUpdateFrom(tempDir)).toBe(false);
+  });
+
+  it("trata arquivo settings.json corrompido retornando true (padrao seguro)", () => {
+    const file = path.join(tempDir, "settings.json");
+    fs.writeFileSync(file, "{ invalid json content ... ");
+    expect(readAutoUpdateFrom(tempDir)).toBe(true);
+  });
+});


### PR DESCRIPTION
## O que foi feito

Este PR traz duas melhorias de UX para o cliente desktop:

1. **Exibição da versão instalada (`feat: exibir versao instalada na interface e bandeja`)**:
   - A versão agora é mostrada no cabeçalho da interface (`GO LIVE · BRASIL · V1.1.9`), na barra de título e no tooltip/menu da bandeja do sistema.

2. **Toggle para controle de notificações de atualização (`feat: adicionar opcao para desativar notificacoes de atualizacao`)**:
   - Adicionada opção switch *"Avisar sobre atualizações"* na interface e checkbox na bandeja do sistema (ativo por padrão).
   - Quando desativado, o app não realiza checagens em background nem exibe caixas de diálogo de atualização.
   - Configuração persistida no `settings.json`.

## Testes
- Adicionados testes unitários para a persistência e defaults da configuração (`tests/updater-settings.test.ts`).
- Suíte completa de testes (`npm test`) passando (58/58).
- Compilação (`npm run compile`) validada.