### PR TITLE
fix(instalador/standalone): Set-RunKey não apaga mais o startup do usuário

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@ segue [Semantic Versioning](https://semver.org/lang/pt-BR/).
   agora existe também no Windows.
 
 ### Corrigido
+- **`Set-RunKey` apagava todas as entradas de inicialização do usuário**: no
+  provider de registro do PowerShell (ao contrário do de arquivos),
+  `New-Item -Path <chave> -Force` numa chave que **já existe** apaga a chave e
+  recria vazia. Como o `Set-RunKey` do instalador e do standalone chamava isso
+  em `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` antes de gravar o
+  `GoLiveBypassTor`, toda execução limpava o startup da máquina (Spotify,
+  Steam, Discord…) e deixava só a nossa entrada. Passava despercebido porque os
+  poucos apps que reescrevem a própria entrada a cada abertura (como o Docker
+  Desktop) reaparecem sozinhos, e porque a chave `StartupApproved` — que a tela
+  "Inicializar" do Windows lê — não é tocada e continua listando tudo, então a
+  lista da interface parece intacta. Agora a chave Run só é criada se realmente
+  faltar.
 - **Refresh do Tor em modo `tor` segurava o gateway por até 12s** quando o
   daemon oscilava: `refreshExit` chamava `detectTor()` com timeout de 6s
   para o probe + 6s para `exitCountryTorCached`. Em modo `tor` o bypass

--- a/installer/GoLiveBypass-Installer.ps1
+++ b/installer/GoLiveBypass-Installer.ps1
@@ -1376,8 +1376,16 @@ Log notice stdout
 function Set-RunKey($exe, $torrc) {
     try {
         $command = "`"$exe`" -f `"$torrc`""
-        New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Force | Out-Null
-        Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'GoLiveBypassTor' -Value $command
+        # ATENCAO: nada de "New-Item -Path <chave> -Force" aqui. No provider de
+        # registro (diferente do de arquivos) o -Force numa chave que ja existe
+        # APAGA a chave e recria vazia, levando junto todas as entradas de
+        # inicializacao do usuario (Spotify, Steam, Discord...).
+        # A chave Run sempre existe no Windows; so criamos se realmente faltar.
+        $key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+        if (-not (Test-Path -LiteralPath $key)) {
+            New-Item -Path $key -Force | Out-Null
+        }
+        Set-ItemProperty -Path $key -Name 'GoLiveBypassTor' -Value $command
         Write-Ok 'Tor registrado para subir no proximo logon (GoLiveBypassTor).'
         return $true
     } catch {

--- a/standalone/GoLiveBypass-Standalone.ps1
+++ b/standalone/GoLiveBypass-Standalone.ps1
@@ -745,8 +745,16 @@ function Install-Tor {
 function Set-RunKey {
     try {
         $command = "`"$TorExe`" -f `"$TorTorrc`""
-        New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Force | Out-Null
-        Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'GoLiveBypassTor' -Value $command
+        # ATENCAO: nada de "New-Item -Path <chave> -Force" aqui. No provider de
+        # registro (diferente do de arquivos) o -Force numa chave que ja existe
+        # APAGA a chave e recria vazia, levando junto todas as entradas de
+        # inicializacao do usuario (Spotify, Steam, Discord...).
+        # A chave Run sempre existe no Windows; so criamos se realmente faltar.
+        $key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+        if (-not (Test-Path -LiteralPath $key)) {
+            New-Item -Path $key -Force | Out-Null
+        }
+        Set-ItemProperty -Path $key -Name 'GoLiveBypassTor' -Value $command
         Write-Ok 'Tor registrado para subir no proximo logon (GoLiveBypassTor).'
     } catch {
         Write-Warn "Nao consegui registrar a inicializacao: $($_.Exception.Message)"

--- a/tests/test-run-key.ps1
+++ b/tests/test-run-key.ps1
@@ -1,0 +1,143 @@
+# PowerShell test script for Set-RunKey - regressao do startup do usuario
+#
+# Contexto: no provider de registro do PowerShell (ao contrario do provider de
+# arquivos) o `New-Item -Path <chave> -Force` numa chave que JA EXISTE apaga a
+# chave e a recria vazia, levando junto todos os valores. Set-RunKey usava esse
+# padrao em HKCU\Software\Microsoft\Windows\CurrentVersion\Run, entao toda
+# execucao do instalador ou do standalone limpava as entradas de inicializacao
+# da maquina e deixava so a nossa.
+#
+# Este teste extrai a Set-RunKey dos dois scripts via AST, aponta ela para uma
+# chave descartavel em HKCU e verifica que os vizinhos sobrevivem. Nao toca na
+# chave Run real em nenhum momento.
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not $repoRoot) { $repoRoot = (Get-Location).Path }
+
+$installerPath  = Join-Path $repoRoot 'installer\GoLiveBypass-Installer.ps1'
+$standalonePath = Join-Path $repoRoot 'standalone\GoLiveBypass-Standalone.ps1'
+
+# Literal exatamente como aparece no codigo, para redirecionar a funcao.
+$RealRunKeyLiteral = "'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'"
+$DestructiveCall   = "New-Item -Path $RealRunKeyLiteral -Force"
+$ScratchRoot       = 'HKCU:\Software\GoLiveBypassTest'
+$ScratchKey        = 'HKCU:\Software\GoLiveBypassTest\RunKeyRegression'
+
+# Valores do Tor usados pela versao standalone (script scope) e pela do
+# instalador (parametros). Caminhos falsos: Set-RunKey so grava string.
+$TorExe   = 'C:\GoLiveBypassTest\tor\tor.exe'
+$TorTorrc = 'C:\GoLiveBypassTest\torrc'
+
+# Stubs: Set-RunKey chama essas funcoes, definidas noutra parte dos scripts.
+function Write-Ok($msg) { }
+function Write-Warn($msg) { }
+
+$pass = 0
+$fail = 0
+
+function Assert-Equal($actual, $expected, $desc) {
+    if ($actual -eq $expected) {
+        $script:pass++
+        Write-Host "  [OK] $desc (Resultado: $actual)" -ForegroundColor Green
+    } else {
+        $script:fail++
+        Write-Host "  [FAIL] $desc (Esperado: $expected, Obtido: $actual)" -ForegroundColor Red
+    }
+}
+
+function Assert-True($actual, $desc) {
+    Assert-Equal ([bool]$actual) $true $desc
+}
+
+function Get-FunctionText($path, $name) {
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$errors)
+    if ($errors.Count -gt 0) {
+        throw "$path possui erros de sintaxe; rode tests/test-error-handling.ps1"
+    }
+    $fn = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
+    }, $true)
+    if (-not $fn) { throw "funcao $name nao encontrada em $path" }
+    return $fn.Extent.Text
+}
+
+function Get-ValueOrNull($key, $name) {
+    try { return Get-ItemPropertyValue -Path $key -Name $name -ErrorAction Stop } catch { return $null }
+}
+
+function Reset-ScratchKey([switch]$Absent) {
+    Remove-Item -LiteralPath $ScratchKey -Recurse -Force -ErrorAction SilentlyContinue
+    if (-not $Absent) { New-Item -Path $ScratchKey -Force | Out-Null }
+}
+
+function Test-SetRunKey($label, $path, $callArgs) {
+    Write-Host "`n-- $label --" -ForegroundColor Yellow
+
+    $text = Get-FunctionText $path 'Set-RunKey'
+
+    # 1. Estatico: o padrao destrutivo nao pode voltar num refactor.
+    Assert-True (-not $text.Contains($DestructiveCall)) `
+        "$label nao chama New-Item -Force direto sobre a chave Run"
+
+    # 2. Estatico: a criacao da chave tem que estar guardada por Test-Path.
+    Assert-True ($text -match 'Test-Path') `
+        "$label guarda a criacao da chave com Test-Path"
+
+    # Redireciona a funcao para a chave descartavel e define no escopo local.
+    $redirected = $text.Replace($RealRunKeyLiteral, "'$ScratchKey'")
+    Invoke-Expression $redirected
+
+    # 3. Chave ja existente: os vizinhos precisam sobreviver.
+    Reset-ScratchKey
+    Set-ItemProperty -Path $ScratchKey -Name 'Spotify' -Value 'spotify.exe --autostart'
+    Set-ItemProperty -Path $ScratchKey -Name 'Steam'   -Value 'steam.exe -silent'
+    Set-ItemProperty -Path $ScratchKey -Name 'Discord' -Value 'Update.exe --processStart Discord.exe'
+
+    Set-RunKey @callArgs | Out-Null
+
+    $names = @((Get-Item $ScratchKey).GetValueNames())
+    Assert-Equal $names.Count 4 "$label preserva os 3 vizinhos e adiciona o proprio valor"
+    foreach ($n in 'Spotify', 'Steam', 'Discord') {
+        Assert-True ($names -contains $n) "$label mantem a entrada $n"
+    }
+    Assert-True ($names -contains 'GoLiveBypassTor') "$label grava GoLiveBypassTor"
+    Assert-Equal (Get-ValueOrNull $ScratchKey 'Spotify') 'spotify.exe --autostart' `
+        "$label nao altera o valor do vizinho Spotify"
+    Assert-True ((Get-ValueOrNull $ScratchKey 'GoLiveBypassTor') -like '*tor.exe*') `
+        "$label aponta GoLiveBypassTor para o tor.exe"
+
+    # 4. Chave ausente: ainda precisa ser criada (a intencao original do -Force).
+    Reset-ScratchKey -Absent
+    Assert-True (-not (Test-Path -LiteralPath $ScratchKey)) "$label parte de chave ausente"
+
+    Set-RunKey @callArgs | Out-Null
+
+    Assert-True (Test-Path -LiteralPath $ScratchKey) "$label cria a chave quando ela realmente falta"
+    $names = @((Get-Item $ScratchKey).GetValueNames())
+    Assert-Equal $names.Count 1 "$label deixa so o proprio valor na chave recem-criada"
+    Assert-True ($names -contains 'GoLiveBypassTor') "$label grava GoLiveBypassTor na chave nova"
+}
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Set-RunKey: regressao do startup do usuario" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+try {
+    # Standalone: Set-RunKey sem parametros, le $TorExe/$TorTorrc do escopo.
+    Test-SetRunKey 'Standalone' $standalonePath @()
+
+    # Instalador: Set-RunKey($exe, $torrc).
+    Test-SetRunKey 'Instalador' $installerPath @($TorExe, $TorTorrc)
+} finally {
+    Remove-Item -LiteralPath $ScratchRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Resumo dos Testes: $pass passaram, $fail falharam" -ForegroundColor $(if ($fail -eq 0) { 'Green' } else { 'Red' })
+Write-Host "========================================================`n" -ForegroundColor Cyan
+
+if ($fail -gt 0) { exit 1 }


### PR DESCRIPTION
### 📋 Descrição do Problema

  Toda execução do instalador ou do script standalone **apagava as entradas de inicialização do Windows do usuário**. Depois
  de rodar o GoLiveBypass, programas como Spotify, Steam e Discord simplesmente paravam de abrir junto com o Windows — sem erro, sem aviso, e sem voltar depois de reiniciar a máquina.

  O dano é silencioso: nada falha durante a instalação, e a tela "Inicializar" do Windows continua listando os aplicativos
  como se estivesse tudo certo.

  ### 🔍 Causa Raiz

  `Set-RunKey`, presente tanto no instalador quanto no standalone, fazia:

  ```powershell
  New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Force | Out-Null
  Set-ItemProperty -Path 'HKCU:\...\Run' -Name 'GoLiveBypassTor' -Value $command
  ```

  A intenção era *"cria a chave caso ela não exista"*. Mas **no provider de registro do PowerShell o `-Force` tem semântica
  diferente do provider de arquivos**: `New-Item -Path <chave> -Force` numa chave que **já existe** apaga a chave e a recria
  vazia, levando junto todos os valores. No provider de arquivos, `New-Item -Force` sobre um diretório existente é
  inofensivo — e é exatamente daí que vem a confusão.

  Como `HKCU\...\Run` sempre existe no Windows, esse caminho era percorrido em **100% das execuções**: a chave era zerada e
  em seguida recebia apenas o `GoLiveBypassTor`.

  Reprodução mínima, em chave de teste isolada:

  ```
  ANTES:  Spotify, Steam, Discord
          New-Item -Path <chave> -Force
          Set-ItemProperty -Path <chave> -Name 'GoLiveBypassTor' -Value ...
  DEPOIS: GoLiveBypassTor
  ```

  #### Por que passou despercebido

  Dois efeitos mascaram o estrago:

  1. **Alguns apps se reescrevem sozinhos.** Programas como o Docker Desktop regravam a própria entrada de `Run` toda vez
  que abrem, então reaparecem por conta própria e dão a impressão de que o startup está intacto. Os demais só gravam a chave quando a pessoa marca *"iniciar com o Windows"* dentro do próprio app — uma vez apagados, somem de vez.
  2. **A chave `StartupApproved` não é tocada.** É ela que a tela "Inicializar" (Configurações / Gerenciador de Tarefas) usa para lembrar o estado ligado/desligado de cada item. Ela continua listando tudo, mesmo sem o valor correspondente em
  `Run`. O descompasso entre as duas chaves é a assinatura do bug.

  Numa máquina afetada, `HKCU\...\Run` tinha **3 valores** enquanto `StartupApproved\Run` listava **17** — e os três
  sobreviventes eram exatamente os que se reescrevem sozinhos ao abrir.

  ---

  ### 🛠️ Alterações Realizadas

  - **`standalone/GoLiveBypass-Standalone.ps1`** (`Set-RunKey`) e **`installer/GoLiveBypass-Installer.ps1`** (`Set-RunKey`):
  a chave `Run` passa a ser criada somente quando realmente falta, e o `Set-ItemProperty` grava o valor sem destruir os
  vizinhos.

    ```powershell
    $key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
    if (-not (Test-Path -LiteralPath $key)) {
        New-Item -Path $key -Force | Out-Null
    }
    Set-ItemProperty -Path $key -Name 'GoLiveBypassTor' -Value $command
    ```

    Incluído comentário no código explicando a diferença de semântica entre os dois providers, para o `-Force` não voltar
  num refactor futuro.

  - **`tests/test-run-key.ps1`** (novo): teste de regressão, detalhado abaixo.
  - **`CHANGELOG.md`**: entrada em `### Corrigido` do bloco `[1.1.10] - Unreleased`.

  #### Não afetados (verificado)

  - **`golive-gui/electron/startup.ts`** — já estava correto: usa `reg.exe add`/`delete` com `/v <nome>`, que opera apenas
  sobre o valor nomeado, nunca sobre a chave inteira.
  - **`installer/golivebypass-installer.sh`** e **`standalone/golivebypass-standalone.sh`** — não mexem no registro do
  Windows.
  - Varredura no repositório inteiro: nenhuma outra ocorrência de `New-Item` com `-Force` sobre chave de registro.

  ---

  ### 🧪 Teste de Regressão

  `tests/test-run-key.ps1` extrai a `Set-RunKey` dos dois scripts **via AST**, redireciona o literal da chave para uma chave
  descartável em `HKCU:\Software\GoLiveBypassTest\` e exercita a função de verdade. A chave `Run` real nunca é tocada, e a
  chave de teste é removida num `finally`.

  Cobre, para cada um dos dois scripts:

  - **Estático** — o literal `New-Item -Path '<chave Run>' -Force` não pode reaparecer, e a criação da chave tem que estar
  guardada por `Test-Path`.
  - **Chave já existente** — três valores vizinhos são plantados antes da chamada; todos precisam sobreviver, com o conteúdo
  intacto, mais o `GoLiveBypassTor` gravado.
  - **Chave ausente** — a intenção original do `-Force` continua valendo: a chave é criada normalmente quando de fato não
  existe.

  O teste tem dentes — rodando contra o código anterior ele quebra, e contra o corrigido passa:

  ```
  codigo anterior (d6ee1c2):  12 passaram, 14 falharam   -> exit 1
  codigo desta PR:            26 passaram,  0 falharam   -> exit 0
  ```

  A suíte pré-existente `tests/test-error-handling.ps1` continua verde (50/50).

  ---

  ### ⚠️ Impacto para quem já executou

  O fix impede novas perdas, mas **não restaura o que já foi apagado** — os valores não existem mais no registro. Quem foi
  afetado precisa reativar *"iniciar com o Windows"* dentro de cada aplicativo, ou regravar as entradas manualmente. Vale um
  aviso nas notas da release.

  ---

  ### ✅ Checklist de Verificação

  - [x] Comportamento destrutivo reproduzido e confirmado em chave de registro de teste isolada.
  - [x] Teste de regressão automatizado em `tests/test-run-key.ps1` — 26/26, e comprovadamente falha no código anterior.
  - [x] Suíte pré-existente `tests/test-error-handling.ps1` sem regressão (50/50).
  - [x] Sintaxe dos dois `.ps1` validada via parser AST do PowerShell.
  - [x] Repositório varrido em busca de outras ocorrências do mesmo padrão — nenhuma encontrada.
  - [x] Encoding preservado: os dois `.ps1` continuam UTF-8 com BOM e CRLF conforme `.gitattributes`, sem ruído de diff.