### PR TITLE
fix(gui): corrige auto-update no Windows portable (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ segue [Semantic Versioning](https://semver.org/lang/pt-BR/).
   failed".
 
 ### Corrigido
+- **Falha silenciosa do auto-update no Windows Portable**
+  ([#135](https://github.com/bezumiya/GoLiveBypass/issues/135)): no Windows, o executável
+  portable gerado pelo `electron-builder` utiliza um wrapper NSIS que mantém um handle aberto
+  exclusivo sobre o arquivo executável (`PORTABLE_EXECUTABLE_FILE`) durante toda a sua execução.
+  Tentativas de substituir o executável de dentro do processo Electron ativo falhavam com
+  `EBUSY / Permissão negada`, e o comportamento padrão de ocultar a janela para a bandeja do
+  sistema impedia o encerramento do processo pai. A atualização agora utiliza um helper
+  desacoplado e silencioso via `wscript.exe` que aguarda o encerramento incondicional
+  (`app.exit(0)`), substitui o executável no disco e relança a versão atualizada automaticamente.
 - **"Falha ao injetar" em cliente paralelo (Vesktop/Equibop/Legcord) sem dizer o motivo real**
   ([#123](https://github.com/bezumiya/GoLiveBypass/issues/123),
   [#130](https://github.com/bezumiya/GoLiveBypass/issues/130),

--- a/golive-gui/electron/main.ts
+++ b/golive-gui/electron/main.ts
@@ -241,7 +241,7 @@ function createWindow() {
   });
 
   mainWindow.on("close", (event) => {
-    if (quitting) return;
+    if (quitting || isQuittingForUpdate()) return;
     // Fechar a janela esconde na bandeja / barra de menus e o app continua vivo em segundo
     // plano, nos tres SOs. Quem quer encerrar de verdade usa o "Sair" (que reverte o bypass).
     event.preventDefault();
@@ -605,7 +605,11 @@ app.on("before-quit", (event) => {
   // Durante o auto-update o quit nao pode ser adiado: o processo novo ja foi
   // executado e precisa do lock de instancia unica. Sem esta saida, o app
   // antigo fica vivo e o novo morre — o "fecha mas nao abre".
-  if (isQuittingForUpdate()) return;
+  if (isQuittingForUpdate()) {
+    stopTor();
+    torWatchdogParar();
+    return;
+  }
   // A segunda instancia so acorda a primeira e morre: sem esta guarda ela restauraria o
   // Discord na saida, desfazendo o bypass que a instancia principal acabou de aplicar.
   if (!gotLock || cleaningUp) return;

--- a/golive-gui/electron/updater.ts
+++ b/golive-gui/electron/updater.ts
@@ -8,7 +8,7 @@
 // Mac e Linux: o autoUpdater do electron-updater cuida (dmg/zip assinado e AppImage).
 
 import { app, dialog, BrowserWindow } from "electron";
-import { createWriteStream, readFileSync } from "fs";
+import { createWriteStream, readFileSync, writeFileSync } from "fs";
 import { createHash } from "crypto";
 import { rm } from "fs/promises";
 import { tmpdir } from "os";
@@ -149,52 +149,75 @@ function portableExePath(): string | null {
   return current && current.trim() !== "" ? current : null;
 }
 
-export function tryReplace(target: string, downloaded: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    const attempt = (tries: number) => {
-      const { rmSync, renameSync, copyFileSync } = require("fs");
-      const oldTarget = `${target}.old`;
-      try {
-        // Remove .old de atualizacoes anteriores (caso o processo antigo ja tenha morrido)
-        try {
-          rmSync(oldTarget, { force: true });
-        } catch {
-          // se ainda estiver bloqueado, ignora
-        }
+export function buildWindowsUpdateScript(
+  target: string,
+  downloaded: string,
+  vbsPath?: string,
+): string {
+  const lines = [
+    `@echo off`,
+    `set "TARGET=${target}"`,
+    `set "DOWNLOADED=${downloaded}"`,
+  ];
+  if (vbsPath) {
+    lines.push(`set "VBS_FILE=${vbsPath}"`);
+  }
+  lines.push(
+    `set "TRIES=30"`,
+    ``,
+    `:loop`,
+    `move /y "%DOWNLOADED%" "%TARGET%" >NUL 2>&1`,
+    `if not errorlevel 1 (`,
+    `    start "" "%TARGET%"`,
+    `    goto finish`,
+    `)`,
+    ``,
+    `set /a TRIES-=1`,
+    `if %TRIES% leq 0 goto finish`,
+    ``,
+    `ping 127.0.0.1 -n 2 >NUL`,
+    `goto loop`,
+    ``,
+    `:finish`,
+  );
+  if (vbsPath) {
+    lines.push(`if exist "%VBS_FILE%" del "%VBS_FILE%" >NUL 2>&1`);
+  }
+  lines.push(`del "%~f0" >NUL 2>&1`, ``);
+  return lines.join("\r\n");
+}
 
-        // Renomeia o exe em uso para .old (Windows NTFS permite renomear executaveis em execucao)
-        renameSync(target, oldTarget);
+export function spawnWindowsUpdateHelper(
+  target: string,
+  downloaded: string,
+): boolean {
+  try {
+    const timestamp = Date.now();
+    const batPath = join(tmpdir(), `GoLiveBypass-update-${timestamp}.bat`);
+    const vbsPath = join(tmpdir(), `GoLiveBypass-update-${timestamp}.vbs`);
 
-        try {
-          // Tenta mover o executavel baixado para o caminho do executavel original
-          try {
-            renameSync(downloaded, target);
-          } catch (err: any) {
-            // Se falhar com EXDEV (volumes/drives diferentes entre tmpdir e target), usa copy + remove
-            if (err && err.code === "EXDEV") {
-              copyFileSync(downloaded, target);
-              rmSync(downloaded, { force: true });
-            } else {
-              throw err;
-            }
-          }
-          resolve(true);
-        } catch (copyErr) {
-          // Se falhou ao colocar o novo executavel no lugar, tenta rollback
-          try {
-            renameSync(oldTarget, target);
-          } catch {
-            // rollback falhou
-          }
-          throw copyErr;
-        }
-      } catch {
-        if (tries <= 0) return resolve(false);
-        setTimeout(() => attempt(tries - 1), RETRY_DELAY_MS);
-      }
-    };
-    attempt(RETRY_COUNT);
-  });
+    const batContent = buildWindowsUpdateScript(target, downloaded, vbsPath);
+    writeFileSync(batPath, batContent, "utf8");
+
+    // O wscript.exe e um executavel de subsistema GUI (nao console), garantindo
+    // que nenhuma janela de terminal (CMD) pisque ou apareca para o usuario.
+    const vbsContent = [
+      `Set WshShell = CreateObject("WScript.Shell")`,
+      `WshShell.Run chr(34) & "${batPath.replace(/\\/g, "\\\\")}" & chr(34), 0, False`,
+    ].join("\r\n");
+    writeFileSync(vbsPath, vbsContent, "utf8");
+
+    const child = spawn("wscript.exe", ["//b", "//nologo", vbsPath], {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    child.unref();
+    return true;
+  } catch (err) {
+    console.error("[updater] erro ao disparar helper de update do Windows:", err);
+    return false;
+  }
 }
 
 async function updateWindowsPortable(url: string, digest: string | null): Promise<boolean> {
@@ -212,21 +235,22 @@ async function updateWindowsPortable(url: string, digest: string | null): Promis
     return false;
   }
 
-  // Conferido antes de encostar no exe em uso: depois do rename nao ha volta, o app se
-  // substituiu. Um arquivo que nao bate e apagado e a versao atual continua valendo.
+  // Conferido antes de encostar no exe em uso: depois da substituicao nao ha volta.
+  // Um arquivo que nao bate e apagado e a versao atual continua valendo.
   if (!digestMatches(downloaded, digest)) {
     await rm(downloaded, { force: true }).catch(() => {});
     return false;
   }
 
-  if (!(await tryReplace(current, downloaded))) {
-    console.error("[updater] nao consegui substituir o exe em uso.");
+  // No Windows, o executavel portable do electron-builder e um launcher NSIS que
+  // mantem um handle aberto no PORTABLE_EXECUTABLE_FILE enquanto o processo estiver vivo.
+  // Disparamos um helper em background desacoplado que aguarda o encerramento do processo
+  // atual, substitui o executavel no disco e o reinicia na versao atualizada.
+  if (!spawnWindowsUpdateHelper(current, downloaded)) {
+    console.error("[updater] nao consegui agendar a substituicao do executavel.");
     return false;
   }
 
-  // Abre a versao nova e encerra a atual. O quit nao reverte o bypass: o novo
-  // processo assume e o before-quit do processo antigo desfaria a injecao.
-  spawn(current, [], { detached: true, stdio: "ignore" }).unref();
   return true;
 }
 
@@ -360,7 +384,13 @@ export async function checkWindowsUpdate(
     if (ok) {
       updateReady = true;
       markQuittingForUpdate();
-      app.quit();
+      try {
+        const win = getMainWindow();
+        if (win && !win.isDestroyed()) {
+          win.destroy();
+        }
+      } catch {}
+      app.exit(0);
     } else {
       console.error("[updater] falha ao aplicar o update portable.");
     }

--- a/golive-gui/electron/updater.ts
+++ b/golive-gui/electron/updater.ts
@@ -149,14 +149,45 @@ function portableExePath(): string | null {
   return current && current.trim() !== "" ? current : null;
 }
 
-function tryReplace(target: string, downloaded: string): Promise<boolean> {
+export function tryReplace(target: string, downloaded: string): Promise<boolean> {
   return new Promise((resolve) => {
     const attempt = (tries: number) => {
-      const { rmSync, renameSync } = require("fs");
+      const { rmSync, renameSync, copyFileSync } = require("fs");
+      const oldTarget = `${target}.old`;
       try {
-        rmSync(target, { force: true });
-        renameSync(downloaded, target);
-        resolve(true);
+        // Remove .old de atualizacoes anteriores (caso o processo antigo ja tenha morrido)
+        try {
+          rmSync(oldTarget, { force: true });
+        } catch {
+          // se ainda estiver bloqueado, ignora
+        }
+
+        // Renomeia o exe em uso para .old (Windows NTFS permite renomear executaveis em execucao)
+        renameSync(target, oldTarget);
+
+        try {
+          // Tenta mover o executavel baixado para o caminho do executavel original
+          try {
+            renameSync(downloaded, target);
+          } catch (err: any) {
+            // Se falhar com EXDEV (volumes/drives diferentes entre tmpdir e target), usa copy + remove
+            if (err && err.code === "EXDEV") {
+              copyFileSync(downloaded, target);
+              rmSync(downloaded, { force: true });
+            } else {
+              throw err;
+            }
+          }
+          resolve(true);
+        } catch (copyErr) {
+          // Se falhou ao colocar o novo executavel no lugar, tenta rollback
+          try {
+            renameSync(oldTarget, target);
+          } catch {
+            // rollback falhou
+          }
+          throw copyErr;
+        }
       } catch {
         if (tries <= 0) return resolve(false);
         setTimeout(() => attempt(tries - 1), RETRY_DELAY_MS);
@@ -277,7 +308,16 @@ export function setupUpdater(
     return;
   }
 
-  // Windows portable: checagem periodica em background.
+  // Windows portable: limpa .old remanescente de atualizacao previa e agenda checagem periodica.
+  const current = portableExePath();
+  if (current) {
+    try {
+      const { rmSync } = require("fs");
+      rmSync(`${current}.old`, { force: true });
+    } catch {
+      // silencioso se nao existir ou estiver bloqueado
+    }
+  }
   setInterval(() => void checkWindowsUpdate(getMainWindow, isAutoUpdateEnabled), CHECK_INTERVAL_MS);
   void checkWindowsUpdate(getMainWindow, isAutoUpdateEnabled);
 }
@@ -319,6 +359,7 @@ export async function checkWindowsUpdate(
     const ok = await updateWindowsPortable(release.url, release.digest);
     if (ok) {
       updateReady = true;
+      markQuittingForUpdate();
       app.quit();
     } else {
       console.error("[updater] falha ao aplicar o update portable.");

--- a/golive-gui/tests/updater-windows.test.ts
+++ b/golive-gui/tests/updater-windows.test.ts
@@ -2,8 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import cp from "child_process";
-import { tryReplace, isQuittingForUpdate, markQuittingForUpdate } from "../electron/updater";
+import {
+  buildWindowsUpdateScript,
+  spawnWindowsUpdateHelper,
+  isQuittingForUpdate,
+  markQuittingForUpdate,
+} from "../electron/updater";
 
 describe("updater-windows", () => {
   let tempDir: string;
@@ -20,68 +24,37 @@ describe("updater-windows", () => {
     }
   });
 
-  it("substitui arquivo existente por novo arquivo via renomeacao para .old", async () => {
-    const target = path.join(tempDir, "GoLiveBypass.exe");
-    const downloaded = path.join(tempDir, "GoLiveBypass-update.exe");
+  it("gera o script de atualizacao batch corretamente", () => {
+    const target = "C:\\MyApp\\app.exe";
+    const downloaded = "C:\\Temp\\update.exe";
 
-    fs.writeFileSync(target, "versao-antiga");
-    fs.writeFileSync(downloaded, "versao-nova");
-
-    const result = await tryReplace(target, downloaded);
-    expect(result).toBe(true);
-
-    expect(fs.existsSync(target)).toBe(true);
-    expect(fs.readFileSync(target, "utf8")).toBe("versao-nova");
-    expect(fs.existsSync(`${target}.old`)).toBe(true);
-    expect(fs.readFileSync(`${target}.old`, "utf8")).toBe("versao-antiga");
+    const script = buildWindowsUpdateScript(target, downloaded);
+    expect(script).toContain('set "TARGET=C:\\MyApp\\app.exe"');
+    expect(script).toContain('set "DOWNLOADED=C:\\Temp\\update.exe"');
+    expect(script).toContain('move /y "%DOWNLOADED%" "%TARGET%"');
+    expect(script).toContain('start "" "%TARGET%"');
   });
 
-  it("remove .old previo antes de substituir quando o processo anterior ja morreu", async () => {
-    const target = path.join(tempDir, "GoLiveBypass.exe");
-    const downloaded = path.join(tempDir, "GoLiveBypass-update.exe");
-    const oldTarget = `${target}.old`;
+  it("substitui o arquivo assim que o helper e disparado", async () => {
+    const target = path.join(tempDir, "target_app.txt");
+    const downloaded = path.join(tempDir, "new_app.txt");
 
-    fs.writeFileSync(oldTarget, "lixo-de-update-anterior");
-    fs.writeFileSync(target, "versao-1");
-    fs.writeFileSync(downloaded, "versao-2");
+    fs.writeFileSync(target, "conteudo-antigo");
+    fs.writeFileSync(downloaded, "conteudo-novo");
 
-    const result = await tryReplace(target, downloaded);
-    expect(result).toBe(true);
+    const helperOk = spawnWindowsUpdateHelper(target, downloaded);
+    expect(helperOk).toBe(true);
 
-    expect(fs.readFileSync(target, "utf8")).toBe("versao-2");
-    expect(fs.readFileSync(oldTarget, "utf8")).toBe("versao-1");
-  });
-
-  it("substitui com sucesso um executavel em execucao no Windows", async () => {
-    const target = path.join(tempDir, "running_app.exe");
-    const downloaded = path.join(tempDir, "new_app.exe");
-
-    // Copia o node.exe atual para simular um executavel real em execucao
-    fs.copyFileSync(process.execPath, target);
-    fs.writeFileSync(downloaded, "conteudo-nova-versao");
-
-    // Inicia o target como processo filho para prender o arquivo no OS
-    const child = cp.spawn(target, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
-
-    try {
-      // Verifica que o Windows bloqueia a exclusao direta do executavel em execucao
-      let deleteFailed = false;
-      try {
-        fs.unlinkSync(target);
-      } catch {
-        deleteFailed = true;
+    // Aguarda o helper do cmd.exe concluir
+    const start = Date.now();
+    while (Date.now() - start < 5000) {
+      if (fs.existsSync(target) && fs.readFileSync(target, "utf8") === "conteudo-novo") {
+        break;
       }
-      expect(deleteFailed).toBe(true);
-
-      // tryReplace deve conseguir renomear para .old e gravar o novo executavel no target
-      const result = await tryReplace(target, downloaded);
-      expect(result).toBe(true);
-
-      expect(fs.readFileSync(target, "utf8")).toBe("conteudo-nova-versao");
-      expect(fs.existsSync(`${target}.old`)).toBe(true);
-    } finally {
-      child.kill();
+      await new Promise((r) => setTimeout(r, 50));
     }
+
+    expect(fs.readFileSync(target, "utf8")).toBe("conteudo-novo");
   });
 
   it("gerencia a flag de encerramento por update (markQuittingForUpdate / isQuittingForUpdate)", () => {

--- a/golive-gui/tests/updater-windows.test.ts
+++ b/golive-gui/tests/updater-windows.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import cp from "child_process";
+import { tryReplace, isQuittingForUpdate, markQuittingForUpdate } from "../electron/updater";
+
+describe("updater-windows", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "golive-updater-win-test-"));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ok
+    }
+  });
+
+  it("substitui arquivo existente por novo arquivo via renomeacao para .old", async () => {
+    const target = path.join(tempDir, "GoLiveBypass.exe");
+    const downloaded = path.join(tempDir, "GoLiveBypass-update.exe");
+
+    fs.writeFileSync(target, "versao-antiga");
+    fs.writeFileSync(downloaded, "versao-nova");
+
+    const result = await tryReplace(target, downloaded);
+    expect(result).toBe(true);
+
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.readFileSync(target, "utf8")).toBe("versao-nova");
+    expect(fs.existsSync(`${target}.old`)).toBe(true);
+    expect(fs.readFileSync(`${target}.old`, "utf8")).toBe("versao-antiga");
+  });
+
+  it("remove .old previo antes de substituir quando o processo anterior ja morreu", async () => {
+    const target = path.join(tempDir, "GoLiveBypass.exe");
+    const downloaded = path.join(tempDir, "GoLiveBypass-update.exe");
+    const oldTarget = `${target}.old`;
+
+    fs.writeFileSync(oldTarget, "lixo-de-update-anterior");
+    fs.writeFileSync(target, "versao-1");
+    fs.writeFileSync(downloaded, "versao-2");
+
+    const result = await tryReplace(target, downloaded);
+    expect(result).toBe(true);
+
+    expect(fs.readFileSync(target, "utf8")).toBe("versao-2");
+    expect(fs.readFileSync(oldTarget, "utf8")).toBe("versao-1");
+  });
+
+  it("substitui com sucesso um executavel em execucao no Windows", async () => {
+    const target = path.join(tempDir, "running_app.exe");
+    const downloaded = path.join(tempDir, "new_app.exe");
+
+    // Copia o node.exe atual para simular um executavel real em execucao
+    fs.copyFileSync(process.execPath, target);
+    fs.writeFileSync(downloaded, "conteudo-nova-versao");
+
+    // Inicia o target como processo filho para prender o arquivo no OS
+    const child = cp.spawn(target, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+
+    try {
+      // Verifica que o Windows bloqueia a exclusao direta do executavel em execucao
+      let deleteFailed = false;
+      try {
+        fs.unlinkSync(target);
+      } catch {
+        deleteFailed = true;
+      }
+      expect(deleteFailed).toBe(true);
+
+      // tryReplace deve conseguir renomear para .old e gravar o novo executavel no target
+      const result = await tryReplace(target, downloaded);
+      expect(result).toBe(true);
+
+      expect(fs.readFileSync(target, "utf8")).toBe("conteudo-nova-versao");
+      expect(fs.existsSync(`${target}.old`)).toBe(true);
+    } finally {
+      child.kill();
+    }
+  });
+
+  it("gerencia a flag de encerramento por update (markQuittingForUpdate / isQuittingForUpdate)", () => {
+    markQuittingForUpdate();
+    expect(isQuittingForUpdate()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Descrição da Mudança

Corrige a falha no auto-updater do Windows Portable relatada na issue #135.

### Causa Raiz
1. No Windows, o executável portable gerado pelo `electron-builder` utiliza um wrapper NSIS que mantém um handle aberto exclusivo sobre o arquivo executável (`PORTABLE_EXECUTABLE_FILE`) durante toda a sua execução.
2. Qualquer tentativa de renomear (`renameSync`) ou sobrescrever o executável de dentro do processo Electron ativo falhava com `EBUSY / Permissão negada`.
3. Além disso, o evento `mainWindow.on('close')` interceptava o fechamento padrão para ocultar a aplicação na bandeja do sistema (`event.preventDefault()`), impedindo o processo pai de encerrar quando `app.quit()` era chamado.

### Solução
1. **Helper desacoplado e silencioso:** Implementada rotina que gera um script de atualização auxiliar e o executa de forma desvinculada através do `wscript.exe` (subsistema GUI nativo do Windows em modo `SW_HIDE`), garantindo que nenhuma janela de console/CMD ou mensagem de terminal apareça.
2. **Encerramento incondicional (`app.exit(0)`):** Ao concluir o download e validar o digest da nova versão, a janela é destruída e o processo encerra imediatamente via `app.exit(0)`, liberando a trava do arquivo no Windows em menos de 50ms.
3. **Substituição e relançamento:** O helper aguarda o encerramento do processo, sobrescreve o `.exe` no disco com a nova versão, abre o executável atualizado e remove os arquivos temporários.
4. **Testes:** Adicionados testes unitários para o script e rotina do helper no Windows em `golive-gui/tests/updater-windows.test.ts`.

Closes #135