### PR TITLE
fix(installer): menu sumia sem mensagem quando o ultimo install achado era Discord puro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,15 @@ segue [Semantic Versioning](https://semver.org/lang/pt-BR/).
   failed".
 
 ### Corrigido
+- **Instalador Linux morria em silêncio antes do menu** (sem issue): com o último
+  install varrido sendo um Discord puro (o caso mais comum), o filtro
+  `is_parallel_install "$r" && printf` de `parallel_installs()` fazia o `while`
+  sair com status 1, o assignment `parallels="$(parallel_installs)"` falhava e o
+  `set -e` encerrava o script inteiro sem mensagem nenhuma — o usuário via
+  "Detectado: ... Fonte nao encontrado" e nada mais acontecia. O filtro agora é
+  um `if`, que termina em status 0 quando a condição é falsa, e a detecção de
+  clientes paralelos (Vesktop/Equibop/Legcord) continua idêntica. Regressão no
+  `tests/test-posix.sh` (seção 9), rodando em sh/ash/bash/dash.
 - **Banner de zumbi da beta 4 disparava em falso — e ficava preso** (achado no
   ciclo da #153): `avaliarSinalGw()` comparava a IDADE do último frame (`srvHa`,
   em ms desde o evento) como se fosse timestamp (`agora - srvHa`); o gate de

--- a/installer/golivebypass-installer.sh
+++ b/installer/golivebypass-installer.sh
@@ -980,8 +980,17 @@ discord_resources() {
 # paralelos, NAO injetaveis pelo instalador de mod). Usado pelo show_status
 # so para informacao.
 parallel_installs() {
+    # O corpo do while precisa terminar em status 0: os callers fazem
+    # `parallels="$(parallel_installs)"` e, com `set -e`, um
+    # `is_parallel_install && printf` curto-circuitado no ULTIMO recurso fazia o
+    # while sair com 1, o assignment falhar e o shell inteiro morrer sem
+    # mensagem nenhuma (menu nunca aparecia quando o ultimo install achado era
+    # um Discord puro, o caso mais comum). Com `if`, sem branch executado o
+    # status e 0 e a funcao sempre termina bem.
     discord_resources | while IFS= read -r resources; do
-        is_parallel_install "$resources" && printf '%s\n' "$resources"
+        if is_parallel_install "$resources"; then
+            printf '%s\n' "$resources"
+        fi
     done
 }
 

--- a/tests/test-posix.sh
+++ b/tests/test-posix.sh
@@ -19,8 +19,12 @@ REPO="$(cd -- "$(dirname -- "$0")/.." && pwd)"
 PASS=0
 FAIL=0
 
-# Escolhe podman ou docker
-if command -v podman >/dev/null 2>&1; then
+# Escolhe podman ou docker. O env pode forcar um runtime (ex.: um wrapper que chama
+# "podman --security-opt label=disable" para rodar em maquina com SELinux enforcing;
+# mesmo padrao do test-parallel-client-mismatch.sh).
+if [ -n "${RUNTIME:-}" ]; then
+    :
+elif command -v podman >/dev/null 2>&1; then
     RUNTIME=podman
 elif command -v docker >/dev/null 2>&1; then
     RUNTIME=docker
@@ -387,6 +391,62 @@ H_EOF
         ok "descoberta de checkout $shell ($img)"
     else
         bad "descoberta de checkout $shell ($img)"
+    fi
+    rm -f "$HARNESS"
+    "$RUNTIME" run --rm -u root -v "$home:/h" debian:stable-slim rm -rf /h >/dev/null 2>&1 || true
+    rm -rf "$home" 2>/dev/null || true
+done
+
+echo
+echo "== 9. instalador: parallel_installs nao derruba o script (set -e) =="
+# Simula o caso real que travava o menu: um Discord PURO varrido por ultimo pelo
+# discord_resources fazia o while de parallel_installs sair com status 1, o
+# assignment `parallels="$(parallel_installs)"` falhava e o `set -e` matava o
+# script inteiro sem mensagem (o instalador "nao fazia nada" depois de
+# "Fonte nao encontrado").
+for spec in \
+    "debian:stable-slim sh" \
+    "alpine:latest ash" \
+    "fedora:latest bash" \
+    "ubuntu:latest dash"
+do
+    set -- $spec
+    img="$1"; shell="$2"
+    home="$(mktemp -d)"
+    # Discord puro no .config (primeira secao da varredura)...
+    mkdir -p "$home/.config/discord/app-1.0.155/resources"
+    printf 'original' > "$home/.config/discord/app-1.0.155/resources/app.asar"
+    # ...um cliente paralelo no meio (secao de pacotes: app.asar direto na raiz,
+    # o unico formato que is_parallel_install reconhece - path termina em /vesktop)...
+    mkdir -p "$home/.local/share/vesktop"
+    printf 'original' > "$home/.local/share/vesktop/app.asar"
+    # ...e outro Discord puro por ULTIMO (secao .var/app): era ele que fazia a
+    # funcao sair com 1 quando o usuario so tinha Discord puro.
+    mkdir -p "$home/.var/app/com.discordapp.Discord/config/discord/app-1.0.0/resources"
+    printf 'original' > "$home/.var/app/com.discordapp.Discord/config/discord/app-1.0.0/resources/app.asar"
+
+    HARNESS="$(mktemp)"
+    awk '/^banner$/{exit} {print}' "$REPO/installer/golivebypass-installer.sh" > "$HARNESS"
+    cat >> "$HARNESS" <<'H_EOF'
+saida="$(parallel_installs)"
+[ "$(printf '%s\n' "$saida" | wc -l)" -eq 1 ] || { echo PARALLEL_BAD; exit 1; }
+case "$saida" in *vesktop*) ;; *) echo PARALLEL_BAD; exit 1 ;; esac
+# So com Discord puro (o caso do usuario): sai 0 e lista nada.
+rm -rf /home/testuser/.local/share/vesktop /home/testuser/.var/app
+saida="$(parallel_installs)"
+[ -z "$saida" ] || { echo PARALLEL_BAD; exit 1; }
+echo PARALLEL_OK
+H_EOF
+
+    if "$RUNTIME" run --rm \
+            -v "$HARNESS:/t.sh:ro" \
+            -v "$home:/home/testuser" \
+            -e HOME=/home/testuser \
+            -e XDG_DATA_HOME=/home/testuser/.local/share \
+            "$img" "$shell" /t.sh 2>/dev/null | grep -q PARALLEL_OK; then
+        ok "parallel_installs $shell ($img)"
+    else
+        bad "parallel_installs $shell ($img)"
     fi
     rm -f "$HARNESS"
     "$RUNTIME" run --rm -u root -v "$home:/h" debian:stable-slim rm -rf /h >/dev/null 2>&1 || true


### PR DESCRIPTION
## O que acontecia

O instalador Linux abria o banner e o bloco `Detectado: ... Fonte nao encontrado` e morria **sem nenhuma mensagem**, antes de mostrar o menu — o usuario via o script "nao fazer nada".

## Causa

`parallel_installs()` filtra os recursos com `is_parallel_install "$r" && printf`. Quando o **ultimo** path varrido pelo `discord_resources` e um Discord puro (o caso mais comum — so Discord instalado, nenhum Vesktop/Equibop/Legcord), o `&&` curto-circuita, o `while` sai com status 1, a funcao devolve 1 e o assignment `parallels="$(parallel_installs)"` no `show_status` (que roda antes do menu) falha. Com `set -eu`, o shell inteiro morre em silencio — confirmado com trace (`sh -x`: ultima linha executada era `parallels=`, exit 1, zero output). Introduzido pelo d6ee1c2, que levou a chamada para o `show_status` (28/08).

## Fix

O filtro virou `if ... then printf ... fi`, que termina em status 0 quando a condicao e falsa; a funcao agora sempre termina bem. A deteccao de Vesktop/Equibop/Legcord fica **identica** (o teste de regressao confirma que um Vesktop fake continua sendo listado).

## Testes

Nova secao 9 no `tests/test-posix.sh`: Discord puro por ultimo na varredura + Vesktop no meio, rodando em sh/ash/bash/dash em 4 imagens. O codigo antigo morre no harness em silencio; o novo passa nos 4 shells (validado localmente com dash em container). De quebra o `RUNTIME` do teste agora respeita override via env (mesmo padrao do `test-parallel-client-mismatch.sh`), necessario para rodar em maquina com SELinux enforcing.

Entrada adicionada no CHANGELOG (1.1.12 Unreleased, "Corrigido").

## Observacao

A suite completa ainda tem falhas pre-existentes do 6de7bc4 (o standalone recusa rodar como root e os testes rodam como root nos containers) — tratadas em PR separado (testes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)