### PR TITLE
fix: deteccao case-sensitive do binario Discord falha com Canary/PTB

### DIFF
--- a/standalone/golivebypass-standalone.sh
+++ b/standalone/golivebypass-standalone.sh
@@ -2694,11 +2694,13 @@ target_can_launch() {
     esac
     if [ -n "$resources" ] && [ -d "$resources" ]; then
         local dc_path
-        dc_path="$(find "$resources/.." -maxdepth 2 -name "Discord" -type f -executable 2>/dev/null | head -1 || true)"
+        dc_path="$(find "$resources/.." -maxdepth 2 -type f -executable \
+            \( -iname "Discord" -o -iname "DiscordCanary" -o -iname "DiscordPTB" \) \
+            2>/dev/null | head -1 || true)"
         [ -n "$dc_path" ] && [ -x "$dc_path" ] && return 0
     fi
     local exe
-    for exe in discord Discord discord-canary discordptb; do
+    for exe in discord Discord discord-canary discordcanary DiscordCanary discordptb DiscordPTB; do
         have "$exe" && return 0
     done
     return 1
@@ -2784,22 +2786,28 @@ start_discord() {
 
     if [ -z "$target_cmd" ] && [ -n "$resources" ] && [ -d "$resources" ]; then
         local dc_path
-        dc_path="$(find "$resources/.." -maxdepth 2 -name "Discord" -type f -executable 2>/dev/null | head -1 || true)"
+        dc_path="$(find "$resources/.." -maxdepth 2 -type f -executable \
+            \( -iname "Discord" -o -iname "DiscordCanary" -o -iname "DiscordPTB" \) \
+            2>/dev/null | head -1 || true)"
         if [ -n "$dc_path" ] && [ -x "$dc_path" ]; then
             target_cmd="$dc_path"
         fi
     fi
 
     if [ -z "$target_cmd" ]; then
-        for exe in discord Discord discord-canary discordptb; do
+	    for exe in discord Discord discord-canary discordcanary DiscordCanary discordptb DiscordPTB; do
             if have "$exe"; then
                 target_cmd="$exe"
                 break
             fi
         done
     fi
-
-    [ -n "$target_cmd" ] || return 1
+    
+    if [ -z "$target_cmd" ]; then
+        printf '[%s] launch=falhou motivo=binario_nao_encontrado resources=%s\n' \
+            "$(date -Is)" "$resources" >>"$discord_log"
+	return 1
+    fi
 
     if [ "${START_DISCORD_HOST_ONLY:-0}" -eq 1 ]; then
         # Rollback: depois de remover um namespace incompleto, reabra o cliente


### PR DESCRIPTION
## O problema

target_can_launch() e start_discord() usam `find -name "Discord"` (case-
sensitive) e uma lista fixa de nomes (`discord Discord discord-canary
discordptb`) pra checar se uma instalação tem um binário lançável. Nenhum
dos dois bate com o nome real de alguns executáveis do Canary (`DiscordCanary`)
ou do PTB (`DiscordPTB`).

Hoje isso fica mascarado pelo select_launch_target(), que simplesmente
pula pro próximo candidato em $FOUND quando target_can_launch() retorna
falso -- entao numa maquina com Flatpak + Canary, por exemplo, ele
"funciona" so porque escolhe o Flatpak sem você perceber que o Canary
nunca foi de fato considerado lançável.

O problema real aparece numa máquina que só tem Canary (ou só PTB)
instalado: select_launch_target() concluiria, errado, que não tem
nenhum alvo lançável, e a ativacao falharia inteira mesmo com um
Discord perfeitamente funcional disponível.

## O que este PR corrige

Torna a detecção de binário case-insensitive e explícita pra Canary/PTB
em ambos os lugares `target_can_launch()` e `start_discord()`, e faz
`start_discord()` logar o motivo quando nenhum binário é encontrado, em
vez de retornar sem deixar rastro.

Não mexe em select_launch_target() nem no fluxo de escolha de alvo --
esse já resolve bem o "qual Discord reabrir" quando há mais de um
funcional. Esse PR só corrige a detecção de "isso é lançável?" que
alimenta aquela escolha.